### PR TITLE
Operators:  `.contains`, `.startsWith`, `.endsWith`

### DIFF
--- a/Sources/MongoKitten/QueryBuilder.swift
+++ b/Sources/MongoKitten/QueryBuilder.swift
@@ -245,7 +245,7 @@ public indirect enum AQT {
         case .not(let aqt):
             return ["$not": ~aqt.document]
         case .contains(let key, let val):
-            return [key: .regularExpression(pattern: "\(val)", options: "m")]
+            return [key: .regularExpression(pattern: val, options: "")]
         case .startsWith(let key, let val):
             return [key: .regularExpression(pattern: "^\(val)", options: "m")]
         case .endsWith(let key, let val):

--- a/Sources/MongoKitten/QueryBuilder.swift
+++ b/Sources/MongoKitten/QueryBuilder.swift
@@ -245,11 +245,11 @@ public indirect enum AQT {
         case .not(let aqt):
             return ["$not": ~aqt.document]
         case .contains(let key, let val):
-            return [key: .string("/\(val.val)/")]
+            return [key: .string("/\(val)/")]
         case .startsWith(let key, let val):
-            return [key: .string("/^\(val.val)/")]
+            return [key: .string("/^\(val)/")]
         case .endsWith(let key, let val):
-            return [key: .string("/\(val.val)$/")]
+            return [key: .string("/\(val)$/")]
         case .nothing:
             return []
         }
@@ -288,14 +288,14 @@ public indirect enum AQT {
     /// Whether nothing needs to be matched. Is always true and just a placeholder
     case nothing
     
-    /// Whether the String value within the `key` contains this `Value` as a String.
-    case contains(key: String, val: ValueProtocol)
+    /// Whether the String value within the `key` contains this `String`.
+    case contains(key: String, val: String)
     
-    /// Whether the String value within the `key` starts with this `Value` as a String.
-    case startsWith(key: String, val: ValueProtocol)
+    /// Whether the String value within the `key` starts with this `String`.
+    case startsWith(key: String, val: String)
     
-    /// Whether the String value within the `key` ends with this `Value` as a String.
-    case endsWith(key: String, val: ValueProtocol)
+    /// Whether the String value within the `key` ends with this `String`.
+    case endsWith(key: String, val: String)
 }
 
 /// The protocol all queries need to comply to
@@ -525,33 +525,21 @@ extension Document {
         case .contains(let key, let val):
             switch doc[key] {
             case .string(let stringVal):
-                if let d = val.val.stringValue {
-                    return stringVal.contains(d)
-                } else {
-                    return false
-                }
+                return stringVal.contains(val)
             default:
                 return false
             }
         case .startsWith(let key, let val):
             switch doc[key] {
             case .string(let stringVal):
-                if let d = val.val.stringValue {
-                    return stringVal.hasPrefix(d)
-                } else {
-                    return false
-                }
+                return stringVal.hasPrefix(val)
             default:
                 return false
             }
         case .endsWith(let key, let val):
             switch doc[key] {
             case .string(let stringVal):
-                if let d = val.val.stringValue {
-                    return stringVal.hasSuffix(d)
-                } else {
-                    return false
-                }
+                return stringVal.hasSuffix(val)
             default:
                 return false
             }

--- a/Sources/MongoKitten/QueryBuilder.swift
+++ b/Sources/MongoKitten/QueryBuilder.swift
@@ -244,6 +244,12 @@ public indirect enum AQT {
             return ["$or": .array(Document(array: expressions)) ]
         case .not(let aqt):
             return ["$not": ~aqt.document]
+        case .contains(let key, let val):
+            return [key: .string("/\(val.val)/")]
+        case .startsWith(let key, let val):
+            return [key: .string("/^\(val.val)/")]
+        case .endsWith(let key, let val):
+            return [key: .string("/\(val.val)$/")]
         case .nothing:
             return []
         }
@@ -281,6 +287,15 @@ public indirect enum AQT {
     
     /// Whether nothing needs to be matched. Is always true and just a placeholder
     case nothing
+    
+    /// Whether the String value within the `key` contains this `Value` as a String.
+    case contains(key: String, val: ValueProtocol)
+    
+    /// Whether the String value within the `key` starts with this `Value` as a String.
+    case startsWith(key: String, val: ValueProtocol)
+    
+    /// Whether the String value within the `key` ends with this `Value` as a String.
+    case endsWith(key: String, val: ValueProtocol)
 }
 
 /// The protocol all queries need to comply to
@@ -507,6 +522,39 @@ extension Document {
             return false
         case .not(let aqt):
             return !self.matches(query: Query(aqt: aqt))
+        case .contains(let key, let val):
+            switch doc[key] {
+            case .string(let stringVal):
+                if let d = val.val.stringValue {
+                    return stringVal.contains(d)
+                } else {
+                    return false
+                }
+            default:
+                return false
+            }
+        case .startsWith(let key, let val):
+            switch doc[key] {
+            case .string(let stringVal):
+                if let d = val.val.stringValue {
+                    return stringVal.hasPrefix(d)
+                } else {
+                    return false
+                }
+            default:
+                return false
+            }
+        case .endsWith(let key, let val):
+            switch doc[key] {
+            case .string(let stringVal):
+                if let d = val.val.stringValue {
+                    return stringVal.hasSuffix(d)
+                } else {
+                    return false
+                }
+            default:
+                return false
+            }
         case .nothing:
             return true
         }

--- a/Sources/MongoKitten/QueryBuilder.swift
+++ b/Sources/MongoKitten/QueryBuilder.swift
@@ -245,11 +245,11 @@ public indirect enum AQT {
         case .not(let aqt):
             return ["$not": ~aqt.document]
         case .contains(let key, let val):
-            return [key: .string("/\(val)/")]
+            return [key: .regularExpression(pattern: "\(val)", options: "m")]
         case .startsWith(let key, let val):
-            return [key: .string("/^\(val)/")]
+            return [key: .regularExpression(pattern: "^\(val)", options: "m")]
         case .endsWith(let key, let val):
-            return [key: .string("/\(val)$/")]
+            return [key: .regularExpression(pattern: "\(val)$", options: "m")]
         case .nothing:
             return []
         }

--- a/Tests/MongoKittenTests/CollectionTests.swift
+++ b/Tests/MongoKittenTests/CollectionTests.swift
@@ -72,6 +72,28 @@ class CollectionTests: XCTestCase {
         XCTAssertEqual(response.count, 2)
         
         XCTAssertEqual(response.first, response2)
+        
+        runContainsQuery()
+        runStartsWithQuery()
+        runEndsWithQuery()
+    }
+    
+    private func runContainsQuery() {
+        let query = Query(aqt: .contains(key: "username", val: "ar"))
+        let response = Array(try! TestManager.wcol.find(matching: query))
+        XCTAssert(response.count == 2)
+    }
+    
+    private func runStartsWithQuery() {
+        let query = Query(aqt: .startsWith(key: "username", val: "har"))
+        let response = Array(try! TestManager.wcol.find(matching: query))
+        XCTAssert(response.count == 2)
+    }
+    
+    private func runEndsWithQuery() {
+        let query = Query(aqt: .endsWith(key: "username", val: "rrie"))
+        let response = Array(try! TestManager.wcol.find(matching: query))
+        XCTAssert(response.count == 2)
     }
     
     func testAggregate() {


### PR DESCRIPTION
- Added the query operators `.contains`, `.startsWith`, `.endsWith` (which only work with Strings)
- Main goal was to get closer parity to Vapor operators.
- ~~Needs tests~~
