### PR TITLE
Update GridFS.swift

### DIFF
--- a/Sources/MongoKitten/GridFS.swift
+++ b/Sources/MongoKitten/GridFS.swift
@@ -161,7 +161,7 @@ public class GridFS {
             let chunk = Array(data[0..<smallestMax])
             
             _ = try chunks.insert(["files_id": ~id,
-                                   "n": ~Int64(n),
+                                   "n": .int64(Int64(n)),
                                    "data": .binary(subtype: .generic, data: chunk)])
             
             n += 1


### PR DESCRIPTION
change ~Int64(n) to .int64(Int64(n)) to remove compile bug error