### PR TITLE
Fix MONGODB-CR authentication

### DIFF
--- a/Sources/MongoKitten/Database.swift
+++ b/Sources/MongoKitten/Database.swift
@@ -448,7 +448,7 @@ extension Database {
         // Check for success
         guard successDocument["ok"] as Int? == 1 else {
             logger.error("Authentication for MongoDB user \(details.username) with MongoCR failed against \(details.database) for the following reason")
-            logger.error((successDocument["errmsg"] as String?)!)
+            logger.error(document)
             throw InternalMongoError.incorrectReply(reply: successResponse)
         }
     }

--- a/Sources/MongoKitten/Database.swift
+++ b/Sources/MongoKitten/Database.swift
@@ -412,11 +412,13 @@ extension Database {
     ///
     /// - throws: When failing authentication, being unable to base64 encode or failing to send/receive messages
     internal func authenticate(mongoCR details: MongoCredentials, usingConnection connection: Server.Connection) throws {
+        let cmd = self["$cmd"]
+
         // Get the server's nonce
-        let response = try self.execute(command: [
+        let nonceMessage = Message.Query(requestID: server.nextMessageID(), flags: [], collection: cmd, numbersToSkip: 0, numbersToReturn: 1, query: [
             "getnonce": Int32(1)
-            ], writing: false)
-        
+            ], returnFields: nil)
+        let response = try server.sendAndAwait(message: nonceMessage, overConnection: connection, timeout: 0)
         // Get the server's challenge
         let document = try firstDocument(in: response)
         
@@ -431,9 +433,8 @@ extension Database {
         bytes.append(contentsOf: "\(details.username):mongo:\(details.password)".utf8)
         
         let digest = MD5.hash(bytes)
-        let key = MD5.hash([UInt8]("\(nonce)\(details.username)\(digest)".utf8)).hexString
+        let key = MD5.hash([UInt8]("\(nonce)\(details.username)\(digest.hexString)".utf8)).hexString
         
-        let cmd = self["$cmd"]
         let commandMessage = Message.Query(requestID: server.nextMessageID(), flags: [], collection: cmd, numbersToSkip: 0, numbersToReturn: 1, query: [
             "authenticate": 1,
             "nonce": nonce,
@@ -447,7 +448,7 @@ extension Database {
         // Check for success
         guard successDocument["ok"] as Int? == 1 else {
             logger.error("Authentication for MongoDB user \(details.username) with MongoCR failed against \(details.database) for the following reason")
-            logger.error(document)
+            logger.error((successDocument["errmsg"] as String?)!)
             throw InternalMongoError.incorrectReply(reply: successResponse)
         }
     }


### PR DESCRIPTION
## Description
### 1. Indefinit recursion
When trying to use MONGODB-CR authentication I found that it didn't work. After some investigation I found that the call to `self.execute` would result in indefinitely recursion into authentication. `self.execute -> server.reserveConnection -> connection.authenticate`.

### 2. Incorrect password hashing
By not using `"\(digest.hexString)"`, but `"\(digest)"` it would serialize the wrong representation of the digest.

## How Has This Been Tested?
After finally solving the authentication (it appeared to work), I found that my server version was not supported (2.4) so I gave up.

## Checklist:
- [ ] If applicable, I have updated the documentation accordingly.
- [ ] If applicable, I have added tests to cover my changes.