### PR TITLE
README update: Added MongoKitten 3 URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,11 +25,17 @@ Alternatively; make use of a DAAS (Database-as-a-service) like [MLab](https://ml
 
 ## Importing
 
-Add this to your dependencies:
+Add this to your Package.swift file:
+
+`.Package(url: "https://github.com/OpenKitten/MongoKitten.git", majorVersion: 3, minor: 0)`
+
+And `import MongoKitten` in your project.
+
+Note: MongoKitten 4 is ready for release, but depends on features coming in the next version of Vapor. If you'd like to take a peek, use this package URL instead.
 
 `.Package(url: "https://github.com/OpenKitten/MongoKitten.git", "4.0.0-vaportls")`
 
-And `import MongoKitten` in your project.
+If you're adding MongoKitten to an existing Xcode project, make sure to rebuild your Xcode project.
 
 ## Supported Features
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Added MongoKitten 3 URL

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
When I added MongoKitten 4 to a new Vapor project, MongoKitten was broken due to an SSL error. I assume this is because it relies on a feature in the development version of Vapor. For beginners, it would help to have the version of MongoKitten compatible with the current production version of Vapor listed. And for users who are interested in using the finished version of MongoKitten 4, I've added a note detailing why it may not work with the current version of Vapor.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
• Added MongoKitten 4 to a new Vapor project, which did not work.
• Added MongoKitten 3 to a new Vapor project, and it worked.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] If applicable, I have updated the documentation accordingly.
- [ ] If applicable, I have added tests to cover my changes.