### PR TITLE
[FIX] Error where server crashed on boot

### DIFF
--- a/Sources/MongoKitten/Querying/QueryBuilder.swift
+++ b/Sources/MongoKitten/Querying/QueryBuilder.swift
@@ -411,18 +411,9 @@ public struct Query: ExpressibleByDictionaryLiteral, ValueConvertible, Expressib
         return self.queryDocument
     }
 
-    /// Initializes an empty query, matching nothing
-    public init() {
-        self.aqt = .nothing
-    }
-
     /// Creates a Query from a Dictionary Literal
     public init(dictionaryLiteral elements: (String, BSON.Primitive?)...) {
-        if elements.count == 0 {
-            self.aqt = .nothing
-        } else {
-            self.aqt = .exactly(Document(dictionaryElements: elements))
-        }
+        self.aqt = .exactly(Document(dictionaryElements: elements))
     }
     
     /// The `Document` that can be sent to the MongoDB Server as a query/filter
@@ -440,11 +431,7 @@ public struct Query: ExpressibleByDictionaryLiteral, ValueConvertible, Expressib
     
     /// Initializes a Query from a Document and uses this Document as the Query
     public init(_ document: Document) {
-        if document.count == 0 {
-            self.aqt = .nothing
-        } else {
-            self.aqt = .exactly(document)
-        }
+        self.aqt = .exactly(document)
     }
     
     /// Creates a textSearch for a specified string


### PR DESCRIPTION
## Preface
Not expecting this PR to be approved, just wanted to show you where the bug I found was and this PR is what made the server work again for me. I don't really understand the underlying code, and comments would be great to help me understand the lib a bit better going forward.

## Description
@Joannis and @Obbut per our discussion on slack, having trouble getting Mongo to run at all due to the error:

`fatal error: Error raised at top level: MongoKitten.MongoError.invalidResponse([{"ok":0.0,"errmsg":"Failed to parse: filter: []. 'filter' field must be of BSON type Object.","code":9}])`

I dont actually understand what was going on here, however I isolated the code to these few updates from 705b91dc4b592f93aa05777998cab1421f723f6d

## Motivation and Context
Couldn't run server :( - isolated to 4.08

## How Has This Been Tested?
None