### PR TITLE
docs: Bluemix is now IBM Cloud

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Linux requries the `libssl-dev` library to be installed.
 
 Install MongoDB for [Ubuntu](https://docs.mongodb.com/master/tutorial/install-mongodb-on-ubuntu/), [macOS](https://docs.mongodb.com/master/tutorial/install-mongodb-on-os-x/) or [any other supported Linux Distro](https://docs.mongodb.com/master/administration/install-on-linux/).
 
-Alternatively; make use of a DAAS (Database-as-a-service) like [Atlas](https://cloud.mongodb.com), [MLab](https://mlab.com), [Bluemix](https://www.ibm.com/cloud-computing/bluemix/mongodb-hosting) or any other of the many services.
+Alternatively; make use of a DAAS (Database-as-a-service) like [Atlas](https://cloud.mongodb.com), [MLab](https://mlab.com), [IBM Cloud](https://www.ibm.com/cloud/compose/mongodb) or any other of the many services.
 
 ## Getting started
 


### PR DESCRIPTION
Update the `README.md` to refer to IBM Cloud instead of Bluemix.