### PR TITLE
Big endian support

### DIFF
--- a/Sources/MongoKitten/Database/Database+Administration.swift
+++ b/Sources/MongoKitten/Database/Database+Administration.swift
@@ -38,7 +38,9 @@ extension Database {
             }
         }
         
-        log.verbose("Creating a collection named \"\(name)\" in \(self)\(validator != nil ? " with the provided validator" : "")")
+        #if !arch(s390x) // Remove this after fixing an issue of swift runtime/compiler for s390x
+            log.verbose("Creating a collection named \"\(name)\" in \(self)\(validator != nil ? " with the provided validator" : "")")
+        #endif
         
         if let validator = validator {
             command["validator"] = validator
@@ -74,7 +76,9 @@ extension Database {
         
         var request: Document = ["listCollections": 1]
         
-        log.verbose("Listing all collections\(filter != nil ? " using the provided filter" : "")")
+        #if !arch(s390x) // Remove this after fixing an issue of swift runtime/compiler for s390x
+            log.verbose("Listing all collections\(filter != nil ? " using the provided filter" : "")")
+        #endif
         
         if let filter = filter {
             log.debug("The collections are matches against the following filter: " + filter.makeExtendedJSON().serializedString())

--- a/Sources/MongoKitten/Helpers/SerializationHelpers.swift
+++ b/Sources/MongoKitten/Helpers/SerializationHelpers.swift
@@ -47,7 +47,11 @@ extension Int64 : BSONBytesProtocol {
 extension Int32 : BSONBytesProtocol {
     /// Serializes this Int32 to binary
     internal func makeBytes() -> Bytes {
-        let integer = self.littleEndian
+        #if arch(s390x)
+            let integer = self.bigEndian
+        #else
+            let integer = self.littleEndian
+        #endif
         
         return [
             Byte(integer & 0xFF),

--- a/Sources/MongoKitten/Internals/Message.swift
+++ b/Sources/MongoKitten/Internals/Message.swift
@@ -279,7 +279,13 @@ struct ServerReplyPlaceholder {
                 return Int32(data) as Int32
             } else {
                 advanced = 4
-                return consuming.withMemoryRebound(to: Int32.self, capacity: 1, { $0.pointee })
+                #if arch(s390x)
+                    var data = [UInt8](repeating: 0, count: 4)
+                    memcpy(&data, consuming, 4)
+                    return Int32(data) as Int32
+                #else
+                    return consuming.withMemoryRebound(to: Int32.self, capacity: 1, { $0.pointee })
+                #endif
             }
         }
         


### PR DESCRIPTION
This commit adds the big endian support for conversion between bytes and a typed value such as Int. BSON and CryptoKitten also have endian issues. For use in a big endian machine, Package.swift needs to be updated to include the BSON and CryptoKitten packages that have endian fixes.

Swift is running on an IBM mainframe (http://www.enterpriselinuxinsights.com/swift-programming-language-for-ibm-linuxone/) which is a big endian machine. Big endian support is essential.

I executed all of the unit tests on both x86 and s390x (IBM mainframe). All of the tests passed on x86. Some tests fail on s390x, but the reasons are not related to MongoKitten itself. They are the swift runtime issues. I also tested MongoKitten by using my Kitura application. It worked well.
