### PR TITLE
Added key field for create indexes

### DIFF
--- a/Sources/MongoKitten/Deprecated/Deprecated.swift
+++ b/Sources/MongoKitten/Deprecated/Deprecated.swift
@@ -46,4 +46,59 @@ extension Collection {
             throw MongoError.commandFailure(error: document)
         }
     }
+    
+    /// Creates an `Index` in this `Collection` on the specified keys.
+    ///
+    /// Usage:
+    ///
+    /// ```swift
+    /// // Makes "username" unique and indexed. Sort order doesn't technically matter much
+    /// try collection.createIndex(named: "login", .sort(field: "username", order: .ascending), .unique)
+    /// ```
+    ///
+    /// For more information: https://docs.mongodb.com/manual/reference/command/createIndexes/#dbcmd.createIndexes
+    ///
+    /// - parameter name: The name of this index used to identify it
+    /// - parameter parameters: All `IndexParameter` options applied to the index
+    ///
+    /// - throws: When unable to send the request/receive the response, the authenticated user doesn't have sufficient permissions or an error occurred
+    @available(*, deprecated: 4.1.3, message: "The index key is a required field")
+    public func createIndex(named name: String, withParameters parameters: IndexParameter...) throws {
+        try self.createIndexes([(name: name, parameters: parameters)])
+    }
+    
+    /// Creates multiple indexes as specified
+    ///
+    /// For more information: https://docs.mongodb.com/manual/reference/command/createIndexes/#dbcmd.createIndexes
+    ///
+    /// - parameter indexes: The indexes to create. Accepts an array of tuples (each tuple representing an Index) which an contain a name and always contains an array of `IndexParameter`.
+    ///
+    /// - throws: When unable to send the request/receive the response, the authenticated user doesn't have sufficient permissions or an error occurred
+    @available(*, deprecated: 4.1.3, message: "The index key is a required field")
+    public func createIndexes(_ indexes: [(name: String, parameters: [IndexParameter])]) throws {
+        guard let wireVersion = database.server.serverData?.maxWireVersion , wireVersion >= 2 else {
+            throw MongoError.unsupportedOperations
+        }
+        
+        var indexDocs = [Document]()
+        
+        for index in indexes {
+            var indexDocument: Document = [
+                "name": index.name
+            ]
+            
+            for parameter in index.parameters {
+                indexDocument += parameter.document
+            }
+            
+            indexDocs.append(indexDocument)
+        }
+        
+        
+        let document = try firstDocument(in: try database.execute(command: ["createIndexes": self.name, "indexes": Document(array: indexDocs)]))
+        
+        guard Int(document["ok"]) == 1 else {
+            throw MongoError.commandFailure(error: document)
+        }
+    }
 }

--- a/Sources/MongoKitten/Querying/Index.swift
+++ b/Sources/MongoKitten/Querying/Index.swift
@@ -10,6 +10,38 @@
 
 import BSON
 
+/// Index direction
+///
+/// - asc: ascending direction
+/// - desc: descending direction
+public enum IndexDirection: Int {
+    case asc = 1, desc = -1
+}
+
+/// The name to index and the value of direction
+public struct IndexKey {
+    public let name: String
+    public let direction: IndexDirection
+    
+    /// IndexKey
+    ///
+    /// - Parameter name: The name of the field to index and ascending direction by default
+    public init(_ name: String) {
+        self.name = name
+        self.direction = .asc
+    }
+    
+    /// IndexKey
+    ///
+    /// - Parameters:
+    ///   - name: The name of the field to index
+    ///   - direction: The value is either the index direction or index type
+    public init(_ name: String, direction: IndexDirection) {
+        self.name = name
+        self.direction = direction
+    }
+}
+
 /// The options to apply to the creation of an index.
 ///
 /// - one:


### PR DESCRIPTION
Added key field for create indexes.

## Description
https://docs.mongodb.com/manual/reference/command/createIndexes/#dbcmd.createIndexes
A key field is required for error-free index creation. The statement specifies the key field, index name, and parameters. The key field with the name and direction of the index. The index name is generated from the list of key fields.

The existing implementation has been moved to "deprecated" extensions for Collection.

## Motivation and Context
An error occurred while creating the unique index

## How Has This Been Tested?
Created indexes