### PR TITLE
Demonstrates possible thread safety or resource exhaustion issue on OSX

### DIFF
--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -24,5 +24,5 @@ XCTMain([
     testCase(HelperObjectTests.allTests),    
     testCase(SetupTests.allTests),
     testCase(QueryBuilderTests.allTests),
-    testCase(SocketThreadIssue.allTests),
+    testCase(SocketThreadIssue.allTests)
 ])

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -23,5 +23,6 @@ XCTMain([
     testCase(GridFSTest.allTests),  
     testCase(HelperObjectTests.allTests),    
     testCase(SetupTests.allTests),
-    testCase(QueryBuilderTests.allTests)
+    testCase(QueryBuilderTests.allTests),
+    testCase(SocketThreadIssue.allTests),
 ])

--- a/Tests/MongoKittenTests/SocketThreadIssue.swift
+++ b/Tests/MongoKittenTests/SocketThreadIssue.swift
@@ -73,7 +73,7 @@ class SocketThreadIssue: XCTestCase {
     }
     
     func connectionString() -> String? {
-        return "mongodb://tester:XVpwKjP0hr6ux3yw@danake-shard-00-00-r2jwu.mongodb.net:27017,danake-shard-00-01-r2jwu.mongodb.net:27017,danake-shard-00-02-r2jwu.mongodb.net:27017/test?ssl=true&replicaSet=danake-shard-0&authSource=admin"
+        return nil
     }
     
 

--- a/Tests/MongoKittenTests/SocketThreadIssue.swift
+++ b/Tests/MongoKittenTests/SocketThreadIssue.swift
@@ -9,7 +9,7 @@ import Foundation
 import XCTest
 import MongoKitten
 
-class SocketThreadIssue: XCTestCase {
+public class SocketThreadIssue: XCTestCase {
 
     
     func testDemonstrateSocketFailure() throws {

--- a/Tests/MongoKittenTests/SocketThreadIssue.swift
+++ b/Tests/MongoKittenTests/SocketThreadIssue.swift
@@ -11,6 +11,11 @@ import MongoKitten
 
 public class SocketThreadIssue: XCTestCase {
 
+    public static var allTests: [(String, (SocketThreadIssue) -> () throws -> Void)] {
+        return [
+            ("testDemonstrateSocketFailure", testDemonstrateSocketFailure),
+        ]
+    }
     
     func testDemonstrateSocketFailure() throws {
         struct MyStruct: Codable {

--- a/Tests/MongoKittenTests/SocketThreadIssue.swift
+++ b/Tests/MongoKittenTests/SocketThreadIssue.swift
@@ -1,0 +1,80 @@
+//
+//  SocketThreadIssue.swift
+//  MongoKittenTests
+//
+//  Created by Neal Lester on 6/11/18.
+//
+
+import Foundation
+import XCTest
+import MongoKitten
+
+class SocketThreadIssue: XCTestCase {
+
+    
+    func testDemonstrateSocketFailure() throws {
+        struct MyStruct: Codable {
+            var id = UUID()
+        }
+        if let connectionString = connectionString() {
+            let database = try MongoKitten.Database (connectionString)
+            var trialCounter = 0
+            let workQueue = DispatchQueue (label: "work", attributes: .concurrent)
+            let group = DispatchGroup()
+            let collectionName = "testDemonstrateSocketFailure"
+            while trialCounter < 500 {
+                let intraGroup = DispatchGroup()
+                group.enter()
+                intraGroup.enter()
+                let myStruct = MyStruct()
+                workQueue.async {
+                    do {
+                        let encoder = BSONEncoder()
+                        var document = try encoder.encode(myStruct)
+                        document["_id"] = myStruct.id.uuidString
+                        let collection = database[collectionName]
+                        try collection.insert (document)
+                        intraGroup.leave()
+                    } catch {
+                        XCTFail ("\(error)")
+                    }
+                    switch intraGroup.wait(timeout: DispatchTime.now() + 30.0) {
+                    case .success:
+                        break
+                    default:
+                        XCTFail ("Expected .success")
+                    }
+                    do {
+                        let decoder = BSONDecoder()
+                        let collection = database[collectionName]
+                        let query: Query = "_id" == myStruct.id.uuidString
+                        let retrievedDocument = try collection.findOne(query)!
+                        let retrievedStruct = try decoder.decode(MyStruct.self, from: retrievedDocument)
+                        XCTAssertEqual (myStruct.id.uuidString, retrievedStruct.id.uuidString)
+                        group.leave()
+                    } catch {
+                        XCTFail ("\(error)")
+                    }
+                }
+                trialCounter = trialCounter + 1
+            }
+            switch group.wait(timeout: DispatchTime.now() + 30.0) {
+            case .success:
+                break
+            default:
+                XCTFail ("Expected .success")
+            }
+            let cleanUpCollection = database[collectionName]
+            try cleanUpCollection.remove()
+        } else {
+            XCTFail ("Please provide result for connectionString()")
+        }
+        
+    }
+    
+    func connectionString() -> String? {
+        return "mongodb://tester:XVpwKjP0hr6ux3yw@danake-shard-00-00-r2jwu.mongodb.net:27017,danake-shard-00-01-r2jwu.mongodb.net:27017,danake-shard-00-02-r2jwu.mongodb.net:27017/test?ssl=true&replicaSet=danake-shard-0&authSource=admin"
+    }
+    
+
+}


### PR DESCRIPTION
## Description

This change adds a test which demonstrates a possible thread safety or resource exhaustion issue on OSX. If the issue occurs on linux it does not occur as frequently as on OSX (it did not occur in 8 test runs).

On my OSX system (which is accessing a remote mongo instance on cloud.mongodb.com) running this test reliably produces the exception provided below.

Evidence pointing toward thread issue as opposed to resource exhaustion:

The issue seems to occur even though the test has a reasonable number of sockets open at time of failure (8 - 20). This is the number of sockets reported by netstat -vnp tcp | grep pid where PID is the value reported by Activity Monitor for the process named xctest.

xctest(11165,0x700007cc8000) malloc: *** error for object 0x102493c70: pointer being freed was not allocated
*** set a breakpoint in malloc_error_break to debug

#0	0x00007fff60c90b6e in __pthread_kill ()
#1	0x00007fff60e5b080 in pthread_kill ()
#2	0x00007fff60bec1ae in abort ()
#3	0x00007fff60cea822 in free ()
#4	0x00007fff44d3a920 in SSLRecordServiceWriteQueueInternal ()
#5	0x00007fff44b538a7 in SSLServiceWriteQueue ()
#6	0x00007fff44b57150 in SSLRead ()
#7	0x00000001047db637 in closure #5 in MongoSocket.init(address:port:options:onRead:onError:) at /Users/neal/xcode/MongoKitten/Sources/MongoSocket/Socket.swift:290
#8	0x00000001047dba01 in partial apply for closure #5 in MongoSocket.init(address:port:options:onRead:onError:) ()
#9	0x00000001047dba3d in thunk for @escaping @callee_guaranteed () -> () ()
#10	0x00007fff60b1ce0e in _dispatch_block_async_invoke2 ()
#11	0x00007fff60b06db8 in _dispatch_client_callout ()
#12	0x00007fff60b19e81 in _dispatch_continuation_pop ()
#13	0x00007fff60b09081 in _dispatch_source_invoke ()
#14	0x00007fff60b1b07a in _dispatch_queue_serial_drain ()
#15	0x00007fff60b0e166 in _dispatch_queue_invoke ()
#16	0x00007fff60b1bf0d in _dispatch_root_queue_drain_deferred_wlh ()
#17	0x00007fff60b1fd21 in _dispatch_workloop_worker_thread ()
#18	0x00007fff60e57fd2 in _pthread_wqthread ()
#19	0x00007fff60e57be9 in start_wqthread ()

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [N/A ] If applicable, I have updated the documentation accordingly.
- [X] If applicable, I have added tests to cover my changes.