### PR TITLE
Adding timeout value to the Database constructor

### DIFF
--- a/Sources/MongoKitten/Database/Database.swift
+++ b/Sources/MongoKitten/Database/Database.swift
@@ -115,14 +115,15 @@ public final class Database {
     ///
     /// - parameter url: A MongoDB connection string containing a database name, such as `mongodb://localhost/myDatabase`
     /// - parameter maxConnections: The maximum number of connections to allow to the server
-    public init(_ url: String, maxConnectionsPerServer maxConnections: Int = 100) throws {
+    /// - parameter timeout: The timeout used for connections/queries
+    public init(_ url: String, maxConnectionsPerServer maxConnections: Int = 100, timeout: TimeInterval = 30) throws {
         let path = url.characters.split(separator: "/", maxSplits: 2, omittingEmptySubsequences: true)
         
         guard path.count == 3, let dbname = path.last?.split(separator: "?")[0] else {
             throw MongoError.invalidDatabase("")
         }
         
-        self.server = try Server(url, maxConnectionsPerServer: maxConnections)
+        self.server = try Server(url, maxConnectionsPerServer: maxConnections, defaultTimeout: timeout)
         
         self.name = String(dbname)
         


### PR DESCRIPTION
Adding optional server timeout configuration to the Database constructor.

## Description
Adding optional server timeout configuration to the Database constructor. Default value was set to 30 seconds as it is on the Server class. I've updated the method's quick help documentation as well.

## Motivation and Context
This was basically done so we can change the connection/query timeout easily from the Database constructor which is used on the Mongo Provider for Vapor.

## How Has This Been Tested?
No tests done.

## Checklist:
- [X] If applicable, I have updated the documentation accordingly.
- [ ] If applicable, I have added tests to cover my changes.