### PR TITLE
Feature/transactions

### DIFF
--- a/Sources/MongoKitten/AdministrativeQueries.swift
+++ b/Sources/MongoKitten/AdministrativeQueries.swift
@@ -1,6 +1,9 @@
 import NIO
 
 extension Cluster {
+    /// Lists all databases within this cluster as a MongoKitten Database
+    ///
+    /// This includes the adminsitrative database(s)
     public func listDatabases() -> EventLoopFuture<[Database]> {
         let query = ListDatabases()
         return self.getConnection(writable: false).then { connection in

--- a/Sources/MongoKitten/AdministrativeQueries.swift
+++ b/Sources/MongoKitten/AdministrativeQueries.swift
@@ -6,11 +6,11 @@ extension Cluster {
     /// This includes the adminsitrative database(s)
     public func listDatabases() -> EventLoopFuture<[Database]> {
         let query = ListDatabases()
-        return self.getConnection(writable: false).then { connection in
-            return query.execute(on: connection.implicitSession).map { descriptions in
-                return descriptions.map { description in
-                    return self[description.name]
-                }
+        let collection = self[query.namespace.databaseName][query.namespace.collectionName]
+        
+        return query.execute(on: collection).map { descriptions in
+            return descriptions.map { description in
+                return self[description.name]
             }
         }
     }

--- a/Sources/MongoKitten/AdministrativeQueries.swift
+++ b/Sources/MongoKitten/AdministrativeQueries.swift
@@ -1,0 +1,14 @@
+import NIO
+
+extension Cluster {
+    public func listDatabases() -> EventLoopFuture<[Database]> {
+        let query = ListDatabases()
+        return self.getConnection(writable: false).then { connection in
+            return query.execute(on: connection.implicitSession).map { descriptions in
+                return descriptions.map { description in
+                    return self[description.name]
+                }
+            }
+        }
+    }
+}

--- a/Sources/MongoKitten/Cluster.swift
+++ b/Sources/MongoKitten/Cluster.swift
@@ -1,8 +1,6 @@
 import Foundation
 import NIO
 
-// TODO: https://github.com/mongodb/specifications/tree/master/source/server-selection
-// TODO: https://github.com/mongodb/specifications/tree/master/source/server-discovery-and-monitoring
 // TODO: https://github.com/mongodb/specifications/tree/master/source/max-staleness
 // TODO: https://github.com/mongodb/specifications/tree/master/source/initial-dns-seedlist-discovery
 

--- a/Sources/MongoKitten/Collection.swift
+++ b/Sources/MongoKitten/Collection.swift
@@ -6,6 +6,7 @@ import Foundation
 /// MongoDB stores documents in collections. Collections are analogous to tables in relational databases.
 public class Collection: FutureConvenienceCallable {
     // MARK: Properties
+    internal var transaction: Transaction?
     
     /// The name of the collection
     public let name: String
@@ -15,6 +16,23 @@ public class Collection: FutureConvenienceCallable {
     
     public var eventLoop: EventLoop {
         return cluster.eventLoop
+    }
+    
+    internal func makeTransactionQueryOptions() -> TransactionQueryOptions? {
+        guard let transaction = transaction else {
+            return nil
+        }
+        
+        defer {
+            transaction.started = true
+            transaction.active = true
+        }
+        
+        return TransactionQueryOptions(
+            id: transaction.id,
+            startTransaction: !transaction.started,
+            autocommit: transaction.autocommit ?? false
+        )
     }
     
     internal var session: ClientSession
@@ -77,7 +95,7 @@ public class Collection: FutureConvenienceCallable {
     /// - parameter query: The query to execute. Defaults to an empty query that counts every document.
     /// - returns: The number of documents matching the given query.
     public func count(_ query: Query? = nil) -> EventLoopFuture<Int> {
-        return CountCommand(query, in: self).execute(on: session)
+        return CountCommand(query, in: self).execute(on: self)
     }
     
     /// Finds the distinct values for a specified field across a single collection. distinct returns a document that contains an array of the distinct values. The return document also contains an embedded document with query statistics and the query plan.
@@ -89,7 +107,7 @@ public class Collection: FutureConvenienceCallable {
     public func distinct(onKey key: String, where filter: Query? = nil) -> EventLoopFuture<[Primitive]> {
         var distinct = DistinctCommand(onKey: key, into: self)
         distinct.query = filter
-        return distinct.execute(on: session)
+        return distinct.execute(on: self)
     }
     
     /// Calculates aggregate values for the data in a collection or a view.
@@ -136,9 +154,7 @@ public class Collection: FutureConvenienceCallable {
     /// - see: https://docs.mongodb.com/manual/reference/command/insert/index.html
     @discardableResult
     public func insert(documents: [Document]) -> EventLoopFuture<InsertReply> {
-        return session.cluster.withAssertions(.writable) {
-            return InsertCommand(documents, into: self).execute(on: session)
-        }
+        return InsertCommand(documents, into: self).execute(on: self)
     }
     
     // MARK: Removing documents
@@ -149,11 +165,9 @@ public class Collection: FutureConvenienceCallable {
     /// - parameter query: The filter to apply. Defaults to an empty query, deleting every document.
     /// - returns: The number of documents removed
     public func deleteAll(where query: Query) -> EventLoopFuture<Int> {
-        return session.cluster.withAssertions(.writable) {
-            let delete = DeleteCommand.Single(matching: query, limit: .all)
-            
-            return DeleteCommand([delete], from: self).execute(on: session)
-        }
+        let delete = DeleteCommand.Single(matching: query, limit: .all)
+
+        return DeleteCommand([delete], from: self).execute(on: self)
     }
     
     /// Deletes one document that matches the given query.
@@ -161,11 +175,9 @@ public class Collection: FutureConvenienceCallable {
     /// - parameter query: The filter to apply. Defaults to an empty query
     /// - returns: The number of documents removed
     public func deleteOne(where query: Query) -> EventLoopFuture<Int> {
-        return session.cluster.withAssertions(.writable) {
-            let delete = DeleteCommand.Single(matching: query, limit: .one)
-            
-            return DeleteCommand([delete], from: self).execute(on: session)
-        }
+        let delete = DeleteCommand.Single(matching: query, limit: .one)
+        
+        return DeleteCommand([delete], from: self).execute(on: self)
     }
     
     // MARK: Performing updates
@@ -208,9 +220,7 @@ public class Collection: FutureConvenienceCallable {
     /// - parameter multiple: If set to `true`, more than one document may be updated
     @discardableResult
     public func update(where query: Query, to document: Document, multiple: Bool? = nil) -> EventLoopFuture<UpdateReply> {
-        return session.cluster.withAssertions(.writable) {
-            return UpdateCommand(query, to: document, in: self, multiple: multiple).execute(on: session)
-        }
+        return UpdateCommand(query, to: document, in: self, multiple: multiple).execute(on: self)
     }
     
     /// Updates the document(s) matching the given query to the given `document`. If no document matches the given query, the document will be inserted into the collection.
@@ -219,12 +229,10 @@ public class Collection: FutureConvenienceCallable {
     /// - parameter document: The document to insert or to replace the target document with
     @discardableResult
     public func upsert(where query: Query, to document: Document) -> EventLoopFuture<UpdateReply> {
-        return session.cluster.withAssertions(.writable) {
-            var update = UpdateCommand.Single(matching: query, to: document)
-            update.upsert = true
-            
-            return UpdateCommand(update, in: self).execute(on: session)
-        }
+        var update = UpdateCommand.Single(matching: query, to: document)
+        update.upsert = true
+        
+        return UpdateCommand(update, in: self).execute(on: self)
     }
     
     /// Updates the document(s) matching the given query, setting the values given in `set`.
@@ -257,9 +265,7 @@ public class Collection: FutureConvenienceCallable {
             "$unset": unsetQuery.count > 0 ? unsetQuery : nil
         ]
         
-        return session.cluster.withAssertions(.writable) {
-            return self.update(where: query, to: updateDocument, multiple: multiple)
-        }
+        return self.update(where: query, to: updateDocument, multiple: multiple)
     }
     
     public var indexes: CollectionIndexes {
@@ -267,10 +273,8 @@ public class Collection: FutureConvenienceCallable {
     }
     
     public func drop() -> EventLoopFuture<Void> {
-        return session.cluster.withAssertions(.writable) {
-            let command = AdministrativeCommand(command: DropCollection(named: self.name), on: database.cmd)
-            
-            return command.execute(on: session).map { _ in }
-        }
+        let command = AdministrativeCommand(command: DropCollection(named: self.name), on: database.cmd)
+        
+        return command.execute(on: self).map { _ in }
     }
 }

--- a/Sources/MongoKitten/Commands/AggregateCommand.swift
+++ b/Sources/MongoKitten/Commands/AggregateCommand.swift
@@ -199,7 +199,9 @@ public final class AggregateCursor<Element>: QueryCursor {
     }
     
     public func execute() -> EventLoopFuture<FinalizedCursor<AggregateCursor<Element>>> {
-        return self.collection.session.execute(command: self.operation).mapToResult(for: collection).map { cursor in
+        let transaction = collection.makeTransactionQueryOptions()
+        
+        return self.collection.session.execute(command: self.operation, transaction: transaction).mapToResult(for: collection).map { cursor in
             return FinalizedCursor(basedOn: self, cursor: cursor)
         }
     }
@@ -225,7 +227,7 @@ extension AggregateCursor where Element == Document {
             .getFirstResult()
             .thenThrowing { result in
                 guard let result = result else {
-                    throw MongoKittenError(.unexpectedNil, reason: .noResultDocument)
+                    return 0
                 }
                 
                 return result.count

--- a/Sources/MongoKitten/Commands/AuthenticationCommands+MongoDBCR.swift
+++ b/Sources/MongoKitten/Commands/AuthenticationCommands+MongoDBCR.swift
@@ -54,17 +54,27 @@ struct GetNonceResult: ServerReplyDecodableResult {
 
 extension Connection {
     func authenticateCR(_ username: String, password: String, namespace: Namespace) -> EventLoopFuture<Void> {
-        return GetNonce(namespace: namespace).execute(on: self.implicitSession).then { nonce in
-            var md5 = MD5()
-            
-            let credentials = username + ":mongo:" + password
-            let digest = md5.hash(bytes: Array(credentials.utf8)).hexString
-            let key = nonce + username + digest
-            let keyDigest = md5.hash(bytes: Array(key.utf8)).hexString
-            
-            let authenticate = AuthenticateCR(namespace: namespace, nonce: nonce, user: username, key: keyDigest)
-            
-            return authenticate.execute(on: self.implicitSession)
+        return self._execute(command: GetNonce(namespace: namespace), session: nil, transaction: nil).then { reply -> EventLoopFuture<Void> in
+            do {
+                let nonce = try GetNonceResult(reply: reply).nonce
+                
+                var md5 = MD5()
+                
+                let credentials = username + ":mongo:" + password
+                let digest = md5.hash(bytes: Array(credentials.utf8)).hexString
+                let key = nonce + username + digest
+                let keyDigest = md5.hash(bytes: Array(key.utf8)).hexString
+                
+                let authenticate = AuthenticateCR(namespace: namespace, nonce: nonce, user: username, key: keyDigest)
+                
+                return self._execute(command: authenticate, session: nil, transaction: nil).thenThrowing { reply in
+                    guard try OK(reply: reply).isSuccessful else {
+                        throw MongoKittenError(try GenericErrorReply(reply: reply))
+                    }
+                }
+            } catch {
+                return self.eventLoop.newFailedFuture(error: error)
+            }
         }
     }
 }

--- a/Sources/MongoKitten/Commands/AuthenticationCommands+SASL.swift
+++ b/Sources/MongoKitten/Commands/AuthenticationCommands+SASL.swift
@@ -148,7 +148,7 @@ extension Connection {
             
             // NO session must be used here: https://github.com/mongodb/specifications/blob/master/source/sessions/driver-sessions.rst#when-opening-and-authenticating-a-connection
             // Forced on the current connection
-            return self._execute(command: command, session: nil).then { serverReply in
+            return self._execute(command: command, session: nil, transaction: nil).then { serverReply in
                 do {
                     let reply = try SASLReply(reply: serverReply)
                     
@@ -176,7 +176,7 @@ extension Connection {
                         payload: response
                     )
                     
-                    return self._execute(command: next, session: nil).then { serverReply in
+                    return self._execute(command: next, session: nil, transaction: nil).then { serverReply in
                         do {
                             let reply = try SASLReply(reply: serverReply)
                             
@@ -192,7 +192,7 @@ extension Connection {
                                     payload: ""
                                 )
                                 
-                                return self._execute(command: final, session: nil).thenThrowing { serverReply in
+                                return self._execute(command: final, session: nil, transaction: nil).thenThrowing { serverReply in
                                     let reply = try SASLReply(reply: serverReply)
                                     
                                     guard reply.done else {

--- a/Sources/MongoKitten/Commands/Command.swift
+++ b/Sources/MongoKitten/Commands/Command.swift
@@ -11,7 +11,7 @@ protocol MongoDBCommand: AnyMongoDBCommand {
     associatedtype Reply: ServerReplyInitializableResult
     associatedtype ErrorReply: ServerReplyInitializable
     
-    func execute(on session: ClientSession) -> EventLoopFuture<Reply.Result>
+    func execute(on collection: Collection) -> EventLoopFuture<Reply.Result>
 }
 
 protocol AdministrativeMongoDBCommand: MongoDBCommand where ErrorReply == GenericErrorReply {}
@@ -45,8 +45,9 @@ extension ReadCommand {
 }
 
 extension MongoDBCommand {
-    func execute(on session: ClientSession) -> EventLoopFuture<Reply.Result> {
-        return session.execute(command: self).mapToResult(for: session[self.namespace])
+    func execute(on collection: Collection) -> EventLoopFuture<Reply.Result> {
+        let transaction = collection.makeTransactionQueryOptions()
+        return collection.session.execute(command: self, transaction: transaction).mapToResult(for: collection)
     }
 }
 

--- a/Sources/MongoKitten/Commands/ConnectionHandshakeCommand.swift
+++ b/Sources/MongoKitten/Commands/ConnectionHandshakeCommand.swift
@@ -78,7 +78,11 @@ struct ConnectionHandshakeCommand: AdministrativeMongoDBCommand {
     }
 }
 
-public struct WireVersion: Codable, ExpressibleByIntegerLiteral {
+public struct WireVersion: Codable, Comparable, ExpressibleByIntegerLiteral {
+    public static func < (lhs: WireVersion, rhs: WireVersion) -> Bool {
+        return lhs.version < rhs.version
+    }
+    
     public let version: Int
     
     // Wire version 3

--- a/Sources/MongoKitten/Commands/FindCommand.swift
+++ b/Sources/MongoKitten/Commands/FindCommand.swift
@@ -27,15 +27,15 @@ public struct CursorSettings: Encodable {
     var batchSize: Int?
 }
 
+struct CursorDetails: Codable {
+    var id: Int64
+    var ns: String
+    var firstBatch: [Document]
+}
+
 struct CursorReply: ServerReplyDecodableResult {
     var isSuccessful: Bool {
         return ok == 1
-    }
-    
-    struct CursorDetails: Codable {
-        var id: Int64
-        var ns: String
-        var firstBatch: [Document]
     }
     
     internal let cursor: CursorDetails

--- a/Sources/MongoKitten/Commands/FindCommand.swift
+++ b/Sources/MongoKitten/Commands/FindCommand.swift
@@ -64,7 +64,9 @@ public final class FindCursor: QueryCursor {
     }
     
     public func execute() -> EventLoopFuture<FinalizedCursor<FindCursor>> {
-        return self.collection.database.session.execute(command: self.command).mapToResult(for: collection).map { cursor in
+        let options = collection.makeTransactionQueryOptions()
+        
+        return self.collection.database.session.execute(command: self.command, transaction: options).mapToResult(for: collection).map { cursor in
             return FinalizedCursor(basedOn: self, cursor: cursor)
         }
     }

--- a/Sources/MongoKitten/Commands/GetMoreCommand.swift
+++ b/Sources/MongoKitten/Commands/GetMoreCommand.swift
@@ -19,10 +19,6 @@ internal struct GetMore: AdministrativeMongoDBCommand {
         self.collection = collection.namespace
         self.batchSize = batchSize
     }
-    
-    func execute(on session: ClientSession) -> EventLoopFuture<GetMoreReply> {
-        return session.execute(command: self)
-    }
 }
 
 struct GetMoreReply: ServerReplyDecodable, ServerReplyInitializableResult {

--- a/Sources/MongoKitten/Commands/InsertCommand.swift
+++ b/Sources/MongoKitten/Commands/InsertCommand.swift
@@ -26,11 +26,6 @@ public struct InsertCommand: WriteCommand {
         self.insert = collection.namespace
         self.documents = Array(documents)
     }
-    
-    @discardableResult
-    func execute(on session: ClientSession) -> EventLoopFuture<InsertReply> {
-        return session.execute(command: self)
-    }
 }
 
 public struct InsertReply: ServerReplyDecodableResult {

--- a/Sources/MongoKitten/Commands/ListCollections.swift
+++ b/Sources/MongoKitten/Commands/ListCollections.swift
@@ -1,0 +1,18 @@
+struct ListCollections: AdministrativeMongoDBCommand {
+    typealias Reply = CursorReply
+    
+    var namespace: Namespace {
+        return listCollections.namespace
+    }
+    
+    let listCollections: AdministrativeNamespace
+    var filter: Document?
+    
+    init(inDatabase database: String) {
+        self.listCollections = AdministrativeNamespace(namespace: Namespace(to: "$cmd", inDatabase: database))
+    }
+}
+
+struct CollectionDescription: Codable {
+    let name: String
+}

--- a/Sources/MongoKitten/Commands/ListDatabases.swift
+++ b/Sources/MongoKitten/Commands/ListDatabases.swift
@@ -1,0 +1,29 @@
+struct ListDatabases: AdministrativeMongoDBCommand {
+    typealias Reply = ListDatabasesResponse
+    
+    var namespace: Namespace {
+        return Namespace(to: "$cmd", inDatabase: "admin")
+    }
+    
+    let listDatabases: Int32 = 1
+    var filter: Document?
+    
+    init() {}
+}
+
+struct ListDatabasesResponse: ServerReplyDecodableResult {
+    var isSuccessful: Bool { return true }
+    
+    let databases: [DatabaseDescription]
+    let totalSize: Int
+    
+    func makeResult(on collection: Collection) throws -> [DatabaseDescription] {
+        return databases
+    }
+}
+
+struct DatabaseDescription: Codable {
+    let name: String
+    let sizeOnDisk: Int
+    let empty: Bool
+}

--- a/Sources/MongoKitten/Commands/Namespace.swift
+++ b/Sources/MongoKitten/Commands/Namespace.swift
@@ -17,6 +17,8 @@ internal struct Namespace: Encodable {
 }
 
 internal struct AdministrativeNamespace: Encodable {
+    static let admin = AdministrativeNamespace(namespace: Namespace(to: "$cmd", inDatabase: "admin"))
+    
     let namespace: Namespace
     
     func encode(to encoder: Encoder) throws {

--- a/Sources/MongoKitten/Commands/Namespace.swift
+++ b/Sources/MongoKitten/Commands/Namespace.swift
@@ -15,3 +15,12 @@ internal struct Namespace: Encodable {
         try container.encode(collectionName)
     }
 }
+
+internal struct AdministrativeNamespace: Encodable {
+    let namespace: Namespace
+    
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(Int32(1))
+    }
+}

--- a/Sources/MongoKitten/Commands/TransactionCommands.swift
+++ b/Sources/MongoKitten/Commands/TransactionCommands.swift
@@ -29,6 +29,30 @@ import NIO
 //    }
 //}
 
+struct CommitTransactionCommand: AdministrativeMongoDBCommand {
+    var namespace: Namespace {
+        return commitTransaction.namespace
+    }
+    
+    typealias Reply = OK
+    
+    let commitTransaction = AdministrativeNamespace.admin
+    
+    init() {}
+}
+
+struct AbortTransactionCommand: AdministrativeMongoDBCommand {
+    var namespace: Namespace {
+        return abortTransaction.namespace
+    }
+    
+    typealias Reply = OK
+    
+    let abortTransaction = AdministrativeNamespace.admin
+    
+    init() {}
+}
+
 struct EndSessionsCommand: AdministrativeMongoDBCommand {
     typealias Reply = OK
     

--- a/Sources/MongoKitten/Commands/UpdateCommand.swift
+++ b/Sources/MongoKitten/Commands/UpdateCommand.swift
@@ -77,11 +77,6 @@ public struct UpdateCommand: WriteCommand {
         self.update = collection.namespace
         self.updates = Array(updates)
     }
-    
-    @discardableResult
-    func execute(on session: ClientSession) -> EventLoopFuture<UpdateReply> {
-        return session.execute(command: self)
-    }
 }
 
 public struct UpdateReply: ServerReplyDecodableResult {

--- a/Sources/MongoKitten/Cursor.swift
+++ b/Sources/MongoKitten/Cursor.swift
@@ -407,7 +407,7 @@ public final class FinalizedCursor<Base: QueryCursor> {
         closed = true
         
         let command = KillCursorsCommand([self.cursor.id], in: base.collection.namespace)
-        return command.execute(on: self.cursor.collection.session).map { _ in }
+        return command.execute(on: self.cursor.collection).map { _ in }
     }
 }
 

--- a/Sources/MongoKitten/Database.swift
+++ b/Sources/MongoKitten/Database.swift
@@ -90,12 +90,16 @@ public class Database: FutureConvenienceCallable {
         self.session = session
     }
     
-    public func startSession(with options: SessionOptions) -> Database {
-        let newSession = session.cluster.sessionManager.next(with: options, for: session.cluster)
-        return Database(named: name, session: newSession)
-    }
+    /// Stats a new session which can be used for retryable writes, transactions and more
+//    public func startSession(with options: SessionOptions) -> Database {
+//        let newSession = session.cluster.sessionManager.next(with: options, for: session.cluster)
+//        return Database(named: name, session: newSession)
+//    }
     
-    // TODO: Error for < 4.0 installations
+    /// Creates a new tranasction provided the SessionOptions and optional TransactionOptions
+    ///
+    /// The TransactionDatabase that is created can be used like a normal Database for queries within transactions _only_
+    /// Creating a TransactionCollection is done the same way it's created with a normal Database.
     public func startTransaction(with options: SessionOptions, transactionOptions: TransactionOptions? = nil) throws -> TransactionDatabase {
         guard session.cluster.wireVersion?.supportsReplicaTransactions == true else {
             throw MongoKittenError(.unsupportedFeatureByServer, reason: nil)

--- a/Sources/MongoKitten/Database.swift
+++ b/Sources/MongoKitten/Database.swift
@@ -106,6 +106,9 @@ public final class Database: FutureConvenienceCallable {
         return command.execute(on: session).map { _ in }
     }
     
+    /// Lists all collections your user has knowledge of
+    ///
+    /// Returns them as a MongoKitten Collection with you can query
     public func listCollections() -> EventLoopFuture<[Collection]> {
         return ListCollections(inDatabase: self.name).execute(on: session).then { cursor in
             return CursorDrainer(cursor: cursor).collectAll().thenThrowing { documents in

--- a/Sources/MongoKitten/Database.swift
+++ b/Sources/MongoKitten/Database.swift
@@ -29,6 +29,10 @@ public final class Database: FutureConvenienceCallable {
         return session.cluster.sharedGenerator
     }
     
+    public var cluster: Cluster {
+        return session.cluster
+    }
+    
     /// The NIO event loop.
     public var eventLoop: EventLoop {
         return session.cluster.eventLoop

--- a/Sources/MongoKitten/Error.swift
+++ b/Sources/MongoKitten/Error.swift
@@ -139,6 +139,9 @@ public struct MongoKittenError: Codable, Error, CustomStringConvertible, Equatab
         /// No host was newly known
         case noAvailableHosts
         
+        /// Cannot commit or abort an inactive transaction
+        case inactiveTransaction
+        
         public var description: String {
             switch self {
             case .missingMongoDBScheme: return "The connection URI does not start with the 'mongodb://' scheme"
@@ -146,6 +149,7 @@ public struct MongoKittenError: Codable, Error, CustomStringConvertible, Equatab
             case .scramFailure: return "SCRAM protocol failed, the communication was incorrect"
             case .malformedAuthenticationDetails: return "The authentication details in the URI are malformed and cannot be parsed"
             case .unsupportedAuthenticationMechanism: return "The given authentication mechanism is not supported by MongoKitten"
+            case .inactiveTransaction: return "Cannot commit or abort an inactive transaction"
             case .internalError: return "The reason for the error was internal"
             case .invalidPort: return "The given port number is invalid"
             case .noHostSpecified: return "No host was specified"

--- a/Sources/MongoKitten/Index.swift
+++ b/Sources/MongoKitten/Index.swift
@@ -14,7 +14,7 @@ public struct CollectionIndexes {
     public func create(_ index: Index) -> EventLoopFuture<Void> {
         let command = CreateIndexesCommand([index], for: collection)
         
-        return command.execute(on: collection.session)
+        return command.execute(on: collection)
     }
     
     /// Creates a new sorted compound index by a unique name and keys.

--- a/Sources/MongoKitten/Sessions.swift
+++ b/Sources/MongoKitten/Sessions.swift
@@ -57,8 +57,8 @@ final class ClientSession {
     ///
     /// - parameter command: The `MongoDBCommand` to execute
     /// - returns: The reply to the command
-    func execute<C: MongoDBCommand>(command: C) -> EventLoopFuture<C.Reply> {
-        return cluster.send(command: command, session: self).thenThrowing { reply in
+    func execute<C: MongoDBCommand>(command: C, transaction: TransactionQueryOptions? = nil) -> EventLoopFuture<C.Reply> {
+        return cluster.send(command: command, session: self, transaction: transaction).thenThrowing { reply in
             do {
                 return try C.Reply(reply: reply)
             } catch {
@@ -88,6 +88,17 @@ final class ClientSession {
 internal final class ServerSession {
     let sessionId: SessionIdentifier
     let lastUse: Date
+    private var transaction: Int = 1
+    
+    func nextTransactionNumber() -> Int {
+        defer {
+            // Overflow to negative will break new transactions
+            // MongoDB has no solution other than using a different ServerSession
+            transaction = transaction &+ 1
+        }
+        
+        return transaction
+    }
     
     init(for sessionId: SessionIdentifier) {
         self.sessionId = sessionId
@@ -138,15 +149,19 @@ extension Cluster {
     }
 }
 
-//final class Transaction {
-//    let session: ClientSession
+// TODO: Verify server feature version with https://github.com/mongodb/specifications/blob/master/source/retryable-writes/retryable-writes.rst#supported-server-versions
+/// Supported single-statement write operations include insertOne(), updateOne(), replaceOne(), deleteOne(), findOneAndDelete(), findOneAndReplace(), and findOneAndUpdate().
 //
-//    deinit {
-//
-//    }
-//}
-//
+// Supported multi-statement write operations include insertMany() and bulkWrite(). The ordered option may be true or false. In the case of bulkWrite(), UpdateMany or DeleteMany operations within the requests parameter may make some write commands ineligible for retryability. Drivers MUST evaluate eligibility for each write command sent as part of the bulkWrite()
+// https://github.com/mongodb/specifications/blob/master/source/retryable-writes/retryable-writes.rst#how-will-users-know-which-operations-are-supported
+// Write commands specifying an unacknowledged write concern (e.g. {w: 0})) do not support retryable behavior.
+// https://github.com/mongodb/specifications/blob/master/source/retryable-writes/retryable-writes.rst#unsupported-write-operations
+// TODO: Write commands
+// In MongoDB 4.0 the only supported retryable write commands within a transaction are commitTransaction and abortTransaction. Therefore drivers MUST NOT retry write commands within transactions even when retryWrites has been enabled on the MongoClient. Drivers MUST retry the commitTransaction and abortTransaction commands even when retryWrites has been disabled on the MongoClient. commitTransaction and abortTransaction are retryable write commands and MUST be retried according to the Retryable Writes Specification.
 public struct SessionOptions {
+    public var casualConsistency: Bool?
+    public var defaultTransactionOptions: TransactionOptions?
+    
     public init() {}
 }
 

--- a/Sources/MongoKitten/TransactionCollection.swift
+++ b/Sources/MongoKitten/TransactionCollection.swift
@@ -1,6 +1,62 @@
-public final class TransactionCollecion: Collection {
-    internal init(collection: Collection, session: ClientSession) {
-        super.init(named: collection.name, in: collection.database)
-        self.session = session
+import NIO
+
+public final class TransactionDatabase: Database {
+    internal init(named name: String, session: ClientSession, transaction: Transaction) {
+        super.init(named: name, session: session)
+        
+        self.transaction = transaction
     }
+    
+    public override subscript(collection: String) -> TransactionCollection {
+        let collection = TransactionCollection(named: collection, in: self)
+        collection.transaction = self.transaction
+        return collection
+    }
+}
+
+// TODO: Transitions: https://github.com/mongodb/specifications/raw/master/source/transactions/client-session-transaction-states.png
+public final class TransactionCollection: Collection {
+    public func commit() -> EventLoopFuture<Void> {
+        // Crash if the transaction is `nil`, this is a bad violation of the API
+        guard let transactionQueryOptions = self.makeTransactionQueryOptions(), transaction!.active else {
+            let error = MongoKittenError(.commandFailure, reason: .inactiveTransaction)
+            return eventLoop.newFailedFuture(error: error)
+        }
+        
+        return session.execute(command: CommitTransactionCommand(), transaction: transactionQueryOptions).mapToResult(for: self)
+    }
+    
+    public func abort() -> EventLoopFuture<Void> {
+        // Crash if the transaction is `nil`, this is a bad violation of the API
+        guard let transactionQueryOptions = self.makeTransactionQueryOptions(), transaction!.active else {
+            let error = MongoKittenError(.commandFailure, reason: .inactiveTransaction)
+            return eventLoop.newFailedFuture(error: error)
+        }
+        
+        return session.execute(command: AbortTransactionCommand(), transaction: transactionQueryOptions).mapToResult(for: self)
+    }
+    
+    public func close() {
+//        database.sta
+//        let command = EndSessionsCommand([session.sessionId], inNamespace: namespace)
+    }
+}
+
+final class Transaction {
+    let options: TransactionOptions
+    var active = false
+    var started = false
+    var autocommit: Bool?
+    let id: Int
+    
+    init(options: TransactionOptions, transactionId: Int) {
+        self.options = options
+        self.id = transactionId
+    }
+}
+
+public struct TransactionOptions {
+    // TODO: Read/Write concern and readPreference
+    
+    public init() {}
 }

--- a/Sources/MongoKitten/TransactionCollection.swift
+++ b/Sources/MongoKitten/TransactionCollection.swift
@@ -1,5 +1,8 @@
 import NIO
 
+/// A database specific for a single transaction
+///
+/// Can be subscripted to get a TransactionCollection
 public final class TransactionDatabase: Database {
     internal init(named name: String, session: ClientSession, transaction: Transaction) {
         super.init(named: name, session: session)
@@ -15,7 +18,10 @@ public final class TransactionDatabase: Database {
 }
 
 // TODO: Transitions: https://github.com/mongodb/specifications/raw/master/source/transactions/client-session-transaction-states.png
+
+/// A collection specific for a single transaction
 public final class TransactionCollection: Collection {
+    /// Commits all changes permanently
     public func commit() -> EventLoopFuture<Void> {
         // Crash if the transaction is `nil`, this is a bad violation of the API
         guard let transactionQueryOptions = self.makeTransactionQueryOptions(), transaction!.active else {
@@ -26,6 +32,7 @@ public final class TransactionCollection: Collection {
         return session.execute(command: CommitTransactionCommand(), transaction: transactionQueryOptions).mapToResult(for: self)
     }
     
+    /// Aborts the transaction, rolling back to the old database contents
     public func abort() -> EventLoopFuture<Void> {
         // Crash if the transaction is `nil`, this is a bad violation of the API
         guard let transactionQueryOptions = self.makeTransactionQueryOptions(), transaction!.active else {
@@ -34,11 +41,6 @@ public final class TransactionCollection: Collection {
         }
         
         return session.execute(command: AbortTransactionCommand(), transaction: transactionQueryOptions).mapToResult(for: self)
-    }
-    
-    public func close() {
-//        database.sta
-//        let command = EndSessionsCommand([session.sessionId], inNamespace: namespace)
     }
 }
 

--- a/Tests/MongoKittenTests/CRUDTests.swift
+++ b/Tests/MongoKittenTests/CRUDTests.swift
@@ -39,6 +39,10 @@ class CRUDTests : XCTestCase {
         XCTAssertGreaterThan(dbs.count, 0)
     }
     
+    func testListCollections() throws {
+        print(try cluster["admin"].listCollections().wait().map { $0.fullName })
+    }
+    
 //    func testRangeFind() throws {
 //        try connection.then { connection -> EventLoopFuture<Void> in
 //            let collection = connection["test"]["test"]

--- a/Tests/MongoKittenTests/CRUDTests.swift
+++ b/Tests/MongoKittenTests/CRUDTests.swift
@@ -33,6 +33,12 @@ class CRUDTests : XCTestCase {
         try! cluster[dbName].drop().wait()
     }
     
+    func testListDatabases() throws {
+        let dbs = try cluster.listDatabases().wait()
+        
+        XCTAssertGreaterThan(dbs.count, 0)
+    }
+    
 //    func testRangeFind() throws {
 //        try connection.then { connection -> EventLoopFuture<Void> in
 //            let collection = connection["test"]["test"]

--- a/Tests/MongoKittenTests/CRUDTests.swift
+++ b/Tests/MongoKittenTests/CRUDTests.swift
@@ -7,23 +7,23 @@ let dbName = "test"
 class CRUDTests : XCTestCase {
     let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
     
-    let settings = ConnectionSettings(
-        authentication: .scramSha1(username: "joannis", password: "uPygrsKkyI6tYl1d"),
-        authenticationSource: nil,
-        hosts: [
-            .init(hostname: "ok0-shard-00-00-xkvc1.mongodb.net", port: 27017)
-        ],
-        targetDatabase: nil,
-        useSSL: true,
-        verifySSLCertificates: true,
-        maximumNumberOfConnections: 1,
-        connectTimeout: 0,
-        socketTimeout: 0,
-        applicationName: "Test MK5"
-    )
+//    let settings = ConnectionSettings(
+//        authentication: .scramSha1(username: "joannis", password: "test"),
+//        authenticationSource: nil,
+//        hosts: [
+//            .init(hostname: "ok0-shard-00-00-xkvc1.mongodb.net", port: 27017)
+//        ],
+//        targetDatabase: nil,
+//        useSSL: true,
+//        verifySSLCertificates: true,
+//        maximumNumberOfConnections: 1,
+//        connectTimeout: 0,
+//        socketTimeout: 0,
+//        applicationName: "Test MK5"
+//    )
     
 //    let settings = try! ConnectionSettings("mongodb://mongokitten:xrQqOYD28lvAOKXc@ok0-shard-00-00-xkvc1.mongodb.net:27017?ssl=true")
-//    let settings = try! ConnectionSettings("mongodb://localhost")
+    let settings = try! ConnectionSettings("mongodb://localhost")
     
     var cluster: Cluster!
     


### PR DESCRIPTION
Implements a new transactions API by subclassing Collection and Database with an alternative that is explicitly used for transactions.

## Description

Also adapts some internal mechanisms:
- Adds a WireVersion to Cluster that is the minimum wire version from the last discovery
- Adds options for transactions as per spec (currently unused)
- Subclasses Collection and Database to create a temporary collection/database type specific to a transaction to carry context

## How Has This Been Tested?
- Tested it by making an example application as well as a unit test that tests both abort and commit
- Does not test bad use case flows (committing after abort)

## Checklist:
- [x] If applicable, I have updated the documentation accordingly.
- [x] If applicable, I have added tests to cover my changes.