### PR TITLE
Move CursorDetails back into CursorReply and refactor CursorDrainer into cursor.drain()

### DIFF
--- a/Sources/MongoKitten/Commands/FindCommand.swift
+++ b/Sources/MongoKitten/Commands/FindCommand.swift
@@ -27,13 +27,13 @@ public struct CursorSettings: Encodable {
     var batchSize: Int?
 }
 
-struct CursorDetails: Codable {
-    var id: Int64
-    var ns: String
-    var firstBatch: [Document]
-}
-
 struct CursorReply: ServerReplyDecodableResult {
+    struct CursorDetails: Codable {
+        var id: Int64
+        var ns: String
+        var firstBatch: [Document]
+    }
+    
     var isSuccessful: Bool {
         return ok == 1
     }

--- a/Sources/MongoKitten/Database.swift
+++ b/Sources/MongoKitten/Database.swift
@@ -111,7 +111,7 @@ public final class Database: FutureConvenienceCallable {
     /// Returns them as a MongoKitten Collection with you can query
     public func listCollections() -> EventLoopFuture<[Collection]> {
         return ListCollections(inDatabase: self.name).execute(on: session).then { cursor in
-            return CursorDrainer(cursor: cursor).collectAll().thenThrowing { documents in
+            return cursor.drain().thenThrowing { documents in
                 let decoder = BSONDecoder()
                 return try documents.map { document -> Collection in
                     let description = try decoder.decode(CollectionDescription.self, from: document)


### PR DESCRIPTION
This PR adds to the changes of #180.

## Description

- Refactors `CursorDetails` back into `CursorReply.CursorDetails`
- Make `CursorDrainer` private in favour of `cursor.drain()`, as discussed with @Joannis

## Motivation and Context

- There are two slightly different versions of `CursorDetails`
- `cursor.drain()` is a nicer API than using `CursorDrainer` directly, and serves the same purpose

## How Has This Been Tested?

I didn't, but I'm sure @Joannis will 😉 