### PR TITLE
IBM Cloud rebrand

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ For development, this can be on your local machine.
 
 Install MongoDB for [Ubuntu](https://docs.mongodb.com/master/tutorial/install-mongodb-on-ubuntu/), [macOS](https://docs.mongodb.com/master/tutorial/install-mongodb-on-os-x/) or [any other supported Linux Distro](https://docs.mongodb.com/master/administration/install-on-linux/).
 
-Alternatively, make use of a DAAS (Database-as-a-service) like [MongoDB Atlas](https://cloud.mongodb.com), [MLab](https://mlab.com), [Bluemix](https://www.ibm.com/cloud-computing/bluemix/mongodb-hosting) or any other of the many services.
+Alternatively, make use of a DAAS (Database-as-a-service) like [MongoDB Atlas](https://cloud.mongodb.com), [MLab](https://mlab.com), [IBM Cloud](https://cloud.ibm.com/catalog/services/databases-for-mongodb) or any other of the many services.
 </details>
 
 ## Add MongoKitten to your Swift project 🚀


### PR DESCRIPTION
Updates the link and name for IBM Cloud in the README's *Set up MongoDB*, so users can quickly get started with MongoDB & MongoKitten.

## Description
This change replaces a stale link in the README to the MongoDB service.

## Motivation and Context
IBM Cloud rebranded from its former Bluemix name last summer, and the link here was not relevant to MongoKitten users looking to provision MongoDB.

## Checklist:
- [x] If applicable, I have updated the documentation accordingly.
- [x] If applicable, I have added tests to cover my changes.