### PR TITLE
Add array update operators

### DIFF
--- a/Sources/MongoKitten/Commands/UpdateCommand.swift
+++ b/Sources/MongoKitten/Commands/UpdateCommand.swift
@@ -107,7 +107,7 @@ public struct UpdateReply: ServerReplyDecodableResult {
 /// Modifiers that are available for use in update operations.
 ///
 /// - see: https://docs.mongodb.com/manual/reference/operator/update/
-public enum UpdateOperator: Encodable {
+public enum UpdateOperator: Encodable, PrimitiveConvertible {
     /// The $currentDate operator sets the value of a field to the current date, as a `Date`
     case currentDate(field: String)
     
@@ -135,7 +135,8 @@ public enum UpdateOperator: Encodable {
     /// A custom update operator
     case custom(document: Document)
     
-    public func encode(to encoder: Encoder) throws {
+    /// Converts the operator to a Document
+    private var document: Document {
         let document: Document
         
         switch self {
@@ -159,6 +160,15 @@ public enum UpdateOperator: Encodable {
             document = spec
         }
         
+        return document
+    }
+    
+    /// Converts the operator to a Primitive
+    public func makePrimitive() -> Primitive? {
+        return document
+    }
+    
+    public func encode(to encoder: Encoder) throws {
         try document.encode(to: encoder)
     }
 }

--- a/Sources/MongoKitten/Commands/UpdateCommand.swift
+++ b/Sources/MongoKitten/Commands/UpdateCommand.swift
@@ -176,15 +176,7 @@ public enum UpdateOperator: Encodable, PrimitiveConvertible {
 /// Modifiers that are available for use in array update operations.
 ///
 /// - see: https://docs.mongodb.com/manual/reference/operator/update-array/
-public enum ArrayUpdateOperator: Encodable {
-    
-    // These are primarly used within update operators and thus cannot be represented easily here.
-//    case matchFirst(Primitive)
-    
-//    case matchAll(Primitive)
-    
-//    case matchFiltered(Primitive)
-    
+public enum ArrayUpdateOperator: Encodable, PrimitiveConvertible {
     /// The $addToSet operator adds a value to an array unless the value is already present, in which case $addToSet does nothing to that array.
     case addToSet(field: String, Primitive)
     
@@ -224,16 +216,11 @@ public enum ArrayUpdateOperator: Encodable {
         case sortDescending(field: String?)
     }
     
-    public func encode(to encoder: Encoder) throws {
+    /// Converts the operator to a Document
+    private var document: Document {
         let document: Document
         
         switch self {
-//        case .matchFirst(let value):
-            
-//        case .matchAll(let value):
-            
-//        case .matchFiltered(let value):
-            
         case .addToSet(let field, let value):
             document = ["$addToSet": [field: value] as Document]
         case .popFirst(let field):
@@ -272,6 +259,14 @@ public enum ArrayUpdateOperator: Encodable {
             
             document = ["$push": [field: pushValue] as Document]
         }
+    }
+    
+    /// Converts the operator to a Primitive
+    public func makePrimitive() -> Primitive? {
+        return document
+    }
+    
+    public func encode(to encoder: Encoder) throws {
         try document.encode(to: encoder)
     }
 }

--- a/Sources/MongoKitten/Index.swift
+++ b/Sources/MongoKitten/Index.swift
@@ -89,6 +89,7 @@ public enum IndexType: Codable {
     /// Used by indexType for type-safety
     private enum _IndexTypeNames: String, Codable {
         case text
+        case sphere2d
     }
     
     /// Used by indexType for type-safety
@@ -112,12 +113,14 @@ public enum IndexType: Codable {
             switch try container.decode(_IndexTypeNames.self) {
             case .text:
                 self = .text
+            case .sphere2d:
+                self = .sphere2d
             }
         }
     }
     
     case ascending, descending
-    case text
+    case text, sphere2d
     
     /// Internal helper that translates the index type to a primitive
     var primitive: Primitive {
@@ -128,6 +131,8 @@ public enum IndexType: Codable {
             return -1 as Int32
         case .text:
             return "text"
+        case .sphere2d:
+            return "2dsphere"
         }
     }
     
@@ -144,6 +149,9 @@ public enum IndexType: Codable {
             try container.encode(value)
         case .text:
             let value = "text"
+            try container.encode(value)
+        case .sphere2d:
+            let value = "2dsphere"
             try container.encode(value)
         }
     }


### PR DESCRIPTION
Adding the MongoDB array update operators.

## Description
MongoDB provides several operators for updating arrays on documents. The solution proposes a very similar architecture to the existing UpdateOperator enum.

## Motivation and Context
The change will provide more type safety and feels more swifty. 
The Operators provide for easier discoverability.

## How Has This Been Tested?
Single test for $push, working fine.
No further tests, yet.

## Checklist:
- [ ] If applicable, I have updated the documentation accordingly.
- [ ] If applicable, I have added tests to cover my changes.