### PR TITLE
Added initializer to connect to a database with ConnectionSettings parameter

### DIFF
--- a/Sources/MongoKitten/Database.swift
+++ b/Sources/MongoKitten/Database.swift
@@ -72,6 +72,23 @@ public class Database: FutureConvenienceCallable {
         return try self.connect(uri, on: group).wait()
     }
     
+    /// A helper method that uses the normal `connect` method with the given settings and awaits it. It creates an event loop group for you.
+    ///
+    /// It is not recommended to use `synchronousConnect` in a NIO environment (like Vapor 3), as it will create an event loop group for you.
+    ///
+    /// - parameter settings: The connection settings, which must include a database name
+    /// - throws: Can throw for a variety of reasons, including an invalid connection string, failure to connect to the MongoDB database, etcetera.
+    /// - returns: A connected database instance
+    public static func synchronousConnect(settings: ConnectionSettings) throws -> Database {
+        #if canImport(NIOTransportServices)
+        let group = NIOTSEventLoopGroup(loopCount: 1, defaultQoS: .default)
+        #else
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        #endif
+        
+        return try self.connect(settings: settings, on: group.next()).wait()
+    }
+    
     /// Connect to the database at the given `uri`
     ///
     /// Will postpone queries until initial discovery is complete. Since the cluster is lazily initialized, you'll only know of a failure in connecting (such as wrong credentials) during queries


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Added initializer to connect to a database with ConnectionSettings parameter

## Description
Before you were only allowed to synchronously connect to MongoKitten.Database using a uri, making you only be able to connect to insecure mongo instance. Now we can pass in ConnectionSettings so we can activate ssl, use credentials and etc.

## Motivation and Context
The motivation lies in the need to be able to set the environment variables of a MongoKitten.Database environment when synchronously connecting to the database. By being able to activate ssl, authentication, number of connections and other parameters included in ConnectionSettings, we can do that. Before this pull request, you were unable to do this if you are in non-NIO environment.

## How Has This Been Tested?
Tested local scripts using this method and it works.

## Checklist:
- [ ] If applicable, I have updated the documentation accordingly.
- [ ] If applicable, I have added tests to cover my changes.