### PR TITLE
Increment the nextChunkNumber

### DIFF
--- a/Sources/GridFS/FileWriter.swift
+++ b/Sources/GridFS/FileWriter.swift
@@ -78,6 +78,7 @@ final class FileWriter {
         
         do {
             let chunk = Chunk(filesId: fileId, sequenceNumber: nextChunkNumber, data: .init(buffer: slice))
+            nextChunkNumber += 1
             let encoded = try FileWriter.encoder.encode(chunk)
             
             return fs.chunksCollection.insert(encoded).then { _ in


### PR DESCRIPTION
This fixes an issue with GridFS writes that require more than one chunk. The chunk number was not being correctly incremented.