### PR TITLE
Added helper support for the $addFields pipeline stage.

### DIFF
--- a/Sources/MongoKitten/AggregateBuilder.swift
+++ b/Sources/MongoKitten/AggregateBuilder.swift
@@ -63,6 +63,10 @@ public func match(_ query: Document) -> AggregateBuilderStage {
     return .match(query)
 }
 
+public func addFields(_ query: Document) -> AggregateBuilderStage {
+    return .addFields(query)
+}
+
 public func skip(_ n: Int) -> AggregateBuilderStage {
     return .skip(n)
 }

--- a/Sources/MongoKitten/AggregateStage.swift
+++ b/Sources/MongoKitten/AggregateStage.swift
@@ -17,6 +17,12 @@ public struct AggregateBuilderStage {
         ])
     }
     
+    public static func addFields(_ query: Document) -> AggregateBuilderStage {
+        return AggregateBuilderStage(document: [
+            "$addFields": query
+        ])
+    }
+    
     public static func sort(_ sort: Sort) -> AggregateBuilderStage {
         return AggregateBuilderStage(document: [
             "$sort": sort.document


### PR DESCRIPTION
## Description
Added helper support for the `$addFields` pipeline stage.

## Motivation and Context
Having a convenient helper similar to `match` and `sort` for a common pipeline stage seems helpful

## How Has This Been Tested?
It hasn't 

## Checklist:
- [x] If applicable, I have updated the documentation accordingly.
- [ ] If applicable, I have added tests to cover my changes.