### PR TITLE
Add the upsert variable to the CodingKeys.

### DIFF
--- a/Sources/MongoKittenCore/Commands/Update.swift
+++ b/Sources/MongoKittenCore/Commands/Update.swift
@@ -5,7 +5,7 @@ public struct UpdateCommand: Encodable {
         private enum CodingKeys: String, CodingKey {
             case query = "q"
             case update = "u"
-            case multi, collation, arrayFilters
+            case multi, upsert, collation, arrayFilters
         }
         
         public var query: Document


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Modified the UpdateCommand.UpdateRequest struct to include the upsert variable in the CodingKeys enum.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Performing an upsert operation with a document that does not exist in the collection does not insert the document.
https://github.com/OpenKitten/MongoKitten/issues/215

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested locally.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] If applicable, I have updated the documentation accordingly.
- [ ] If applicable, I have added tests to cover my changes.