### PR TITLE
added --sslCA(mongo client) parameter equivalent for MongoKitten

### DIFF
--- a/Sources/MongoKitten/Connection.swift
+++ b/Sources/MongoKitten/Connection.swift
@@ -89,13 +89,9 @@ internal final class Connection {
         #if canImport(NIOTransportServices)
         var bootstrap = NIOTSConnectionBootstrap(group: cluster.group)
         
-        switch cluster.settings.ssl {
-        case .none:
-            break
-        case .ssl, .sslCA:
+        if cluster.settings.ssl.useSSL {
             bootstrap = bootstrap.tlsOptions(NWProtocolTLS.Options())
         }
-
         #else
         let bootstrap = ClientBootstrap(group: cluster.eventLoop)
         #endif
@@ -178,10 +174,7 @@ internal final class Connection {
             }
         }
         #elseif !canImport(NIOTransportServices)
-        switch settings.ssl {
-        case .none:
-            break
-        case .ssl, .sslCA:
+        if settings.ssl.useSSL {
             promise.fail(error: MongoKittenError(.unableToConnect, reason: .sslNotAvailable))
         }
         #endif

--- a/Sources/MongoKitten/Connection.swift
+++ b/Sources/MongoKitten/Connection.swift
@@ -89,7 +89,7 @@ internal final class Connection {
         #if canImport(NIOTransportServices)
         var bootstrap = NIOTSConnectionBootstrap(group: cluster.group)
         
-        switch settings.ssl {
+        switch cluster.settings.ssl {
         case .none:
             break
         case .ssl, .sslCA:

--- a/Sources/MongoKitten/ConnectionSettings.swift
+++ b/Sources/MongoKitten/ConnectionSettings.swift
@@ -271,8 +271,8 @@ public struct ConnectionSettings: Equatable {
             self.authenticationSource = String(authSource)
         }
         
-        if let useSSL = Bool(queryValue: queries["ssl"]) {
-            self.ssl = useSSL
+        if Bool(queryValue: queries["ssl"]) == true {
+            self.ssl = .ssl
         }
         
         // TODO: Custom root cert for IBM bluemix

--- a/Sources/MongoKitten/ConnectionSettings.swift
+++ b/Sources/MongoKitten/ConnectionSettings.swift
@@ -15,6 +15,18 @@ fileprivate extension Bool {
 
 /// Describes the settings for a MongoDB connection, most of which can be represented in a connection string
 public struct ConnectionSettings: Equatable {
+    /// SSL
+    public enum SSL: Equatable {
+        /// No SSL
+        case none
+        
+        /// Regualar SSL
+        case ssl
+        
+        /// SSL with trust root certificate ( --sslCA variable on mongo client)
+        case sslCA(path: String)
+    }
+
     /// The authentication details to use with the database
     public enum Authentication: Equatable {
         /// Unauthenticated
@@ -82,10 +94,10 @@ public struct ConnectionSettings: Equatable {
     
     /// Hosts to connect to
     public var hosts: [Host]
-    
-    /// When true, SSL will be used
-    public var useSSL: Bool = false
-    
+
+    /// When .ssl, SSL will be used
+    public var ssl: SSL = .none
+
     /// When true, SSL certificates will be validated
     public var verifySSLCertificates: Bool = true
     
@@ -113,18 +125,18 @@ public struct ConnectionSettings: Equatable {
     /// - parameter authenticationSource: See `ConnectionSettings.authenticationSource`
     /// - parameter hosts: Hosts to connect to
     /// - parameter targetDatabase: The target path
-    /// - parameter useSSL: When true, SSL will be used
+    /// - parameter ssl: When .ssl, SSL will be used, when .sslCA(path), provided certificate will be used
     /// - parameter verifySSLCertificates: When true, SSL certificates will be validated
     /// - parameter maximumNumberOfConnections: The maximum number of connections allowed
     /// - parameter connectTimeout: See `ConnectionSettings.connectTimeout`
     /// - parameter socketTimeout: See `ConnectionSettings.socketTimeout`
     /// - parameter applicationName: The application name is printed to the mongod logs upon establishing the connection. It is also recorded in the slow query logs and profile collections.
-    public init(authentication: Authentication, authenticationSource: String? = nil, hosts: [Host], targetDatabase: String? = nil, useSSL: Bool = false, verifySSLCertificates: Bool = true, maximumNumberOfConnections: Int = 1, connectTimeout: TimeInterval = 300, socketTimeout: TimeInterval = 300, applicationName: String? = nil) {
+    public init(authentication: Authentication, authenticationSource: String? = nil, hosts: [Host], targetDatabase: String? = nil, ssl: SSL = .none, verifySSLCertificates: Bool = true, maximumNumberOfConnections: Int = 1, connectTimeout: TimeInterval = 300, socketTimeout: TimeInterval = 300, applicationName: String? = nil) {
         self.authentication = authentication
         self.authenticationSource = authenticationSource
         self.hosts = hosts
         self.targetDatabase = targetDatabase
-        self.useSSL = useSSL
+        self.ssl = ssl
         self.verifySSLCertificates = verifySSLCertificates
         self.maximumNumberOfConnections = maximumNumberOfConnections
         self.connectTimeout = connectTimeout
@@ -158,7 +170,7 @@ public struct ConnectionSettings: Equatable {
             #if canImport(NioDNS)
             uri.removeFirst("mongodb+srv://".count)
             isSRV = true
-            useSSL = true
+            ssl = .ssl
             #else
             throw MongoKittenError(.unsupportedFeatureByClient, reason: .dnsClientNotAvailable)
             #endif
@@ -245,9 +257,9 @@ public struct ConnectionSettings: Equatable {
         if let authSource = queries["authSource"] {
             self.authenticationSource = String(authSource)
         }
-        
-        if let useSSL = Bool(queryValue: queries["ssl"]) {
-            self.useSSL = useSSL
+
+        if Bool(queryValue: queries["ssl"]) == true {
+            self.ssl = .ssl
         }
         
         // TODO: Custom root cert for IBM bluemix


### PR DESCRIPTION
The --sslCA (trust root certificate) is required to connect to AWS DocumentDB.

## Description
Added an option to provide a path to root certificate as part of SSL setting.