### PR TITLE
Added $unwind and $replaceRoot AggregateBuilderStages.

### DIFF
--- a/Sources/MongoKitten/AggregateBuilder.swift
+++ b/Sources/MongoKitten/AggregateBuilder.swift
@@ -123,10 +123,6 @@ public func unwind(
     )
 }
 
-public func replaceRoot(_ newRoot: Document) -> AggregateBuilderStage {
-    return .replaceRoot(newRoot)
-}
-
 public func sort(_ sort: Sort) -> AggregateBuilderStage {
     return .sort(sort)
 }

--- a/Sources/MongoKitten/AggregateBuilder.swift
+++ b/Sources/MongoKitten/AggregateBuilder.swift
@@ -111,6 +111,21 @@ public func lookup(
     )
 }
 
+public func unwind(
+    fieldPath: String,
+    includeArrayIndex: String? = nil,
+    preserveNullAndEmptyArrays: Bool? = nil
+) -> AggregateBuilderStage {
+    return .unwind(
+        fieldPath: fieldPath,
+        includeArrayIndex: includeArrayIndex,
+        preserveNullAndEmptyArrays: preserveNullAndEmptyArrays
+    )
+}
+
+public func replaceRoot(_ newRoot: Document) -> AggregateBuilderStage {
+    return .replaceRoot(newRoot)
+}
 
 public func sort(_ sort: Sort) -> AggregateBuilderStage {
     return .sort(sort)

--- a/Sources/MongoKitten/AggregateStage.swift
+++ b/Sources/MongoKitten/AggregateStage.swift
@@ -110,8 +110,4 @@ public struct AggregateBuilderStage {
         
         return AggregateBuilderStage(document: ["$unwind": d])
     }
-    
-    public static func replaceRoot(_ newRoot: Document) -> AggregateBuilderStage {
-        return AggregateBuilderStage(document: ["$replaceRoot": ["newRoot": newRoot]])
-    }
 }

--- a/Sources/MongoKitten/AggregateStage.swift
+++ b/Sources/MongoKitten/AggregateStage.swift
@@ -110,4 +110,8 @@ public struct AggregateBuilderStage {
         
         return AggregateBuilderStage(document: ["$unwind": d])
     }
+    
+    public static func replaceRoot(_ newRoot: Document) -> AggregateBuilderStage {
+        return AggregateBuilderStage(document: ["$replaceRoot": ["newRoot": newRoot]])
+    }
 }


### PR DESCRIPTION
Added `$unwind` and `$replaceRoot` `AggregateBuilderStage`s.

## Description
This PR adds support for the `$replaceRoot` aggregate stage and adds missing support for `$unwind` to function builder syntax.

## How Has This Been Tested?
It compiles and although these APIs are straight forward, there are no unit tests to verify document output.

## Checklist:
- [x] If applicable, I have updated the documentation accordingly.
- [x] If applicable, I have added tests to cover my changes.