### PR TITLE
New decode function for findOne()

### DIFF
--- a/Sources/MongoKitten/Aggregate.swift
+++ b/Sources/MongoKitten/Aggregate.swift
@@ -112,7 +112,7 @@ public struct AggregateBuilderPipeline: QueryCursor {
                 namespace: self.collection.database.commandNamespace,
                 in: self.collection.transaction,
                 sessionId: self.collection.sessionId ?? connection.implicitSessionId
-            ).decode(CursorReply.self).map { cursor in
+            ).decodeReply(CursorReply.self).map { cursor in
                 let cursor = MongoCursor(
                     reply: cursor.cursor,
                     in: self.collection.namespace,

--- a/Sources/MongoKitten/CollectionHelpers/Collection+Count.swift
+++ b/Sources/MongoKitten/CollectionHelpers/Collection+Count.swift
@@ -14,7 +14,7 @@ extension MongoCollection {
                 in: self.transaction,
                 sessionId: self.sessionId ?? connection.implicitSessionId
             )
-        }.decode(CountReply.self).map { $0.count }._mongoHop(to: hoppedEventLoop)
+        }.decodeReply(CountReply.self).map { $0.count }._mongoHop(to: hoppedEventLoop)
     }
     
     public func count<Query: MongoKittenQuery>(_ query: Query? = nil) -> EventLoopFuture<Int> {

--- a/Sources/MongoKitten/CollectionHelpers/Collection+Delete.swift
+++ b/Sources/MongoKitten/CollectionHelpers/Collection+Delete.swift
@@ -10,7 +10,7 @@ extension MongoCollection {
                 in: self.transaction,
                 sessionId: self.sessionId ?? connection.implicitSessionId
             )
-        }.decode(DeleteReply.self)._mongoHop(to: hoppedEventLoop)
+        }.decodeReply(DeleteReply.self)._mongoHop(to: hoppedEventLoop)
     }
     
     public func deleteAll(where query: Document) -> EventLoopFuture<DeleteReply> {
@@ -21,7 +21,7 @@ extension MongoCollection {
                 in: self.transaction,
                 sessionId: connection.implicitSessionId
             )
-        }.decode(DeleteReply.self)._mongoHop(to: hoppedEventLoop)
+        }.decodeReply(DeleteReply.self)._mongoHop(to: hoppedEventLoop)
     }
     
     public func deleteOne<Q: MongoKittenQuery>(where filter: Q) -> EventLoopFuture<DeleteReply> {

--- a/Sources/MongoKitten/CollectionHelpers/Collection+Distinct.swift
+++ b/Sources/MongoKitten/CollectionHelpers/Collection+Distinct.swift
@@ -11,6 +11,6 @@ extension MongoCollection {
                 in: self.transaction,
                 sessionId: self.sessionId ?? connection.implicitSessionId
             )
-        }.decode(DistinctReply.self).map { $0.distinctValues }._mongoHop(to: hoppedEventLoop)
+        }.decodeReply(DistinctReply.self).map { $0.distinctValues }._mongoHop(to: hoppedEventLoop)
     }
 }

--- a/Sources/MongoKitten/CollectionHelpers/Collection+Find.swift
+++ b/Sources/MongoKitten/CollectionHelpers/Collection+Find.swift
@@ -18,6 +18,10 @@ extension MongoCollection {
         return find(query.makeDocument())
     }
 
+    public func find<D: Decodable>(_ query: Document = [:], as type: D.Type) -> MappedCursor<FindQueryBuilder, D> {
+        return find(query).decode(type)
+    }
+
     public func findOne<D: Decodable>(_ query: Document = [:], as type: D.Type) -> EventLoopFuture<D?> {
         return find(query).limit(1).decode(type).firstResult()
     }

--- a/Sources/MongoKitten/CollectionHelpers/Collection+Insert.swift
+++ b/Sources/MongoKitten/CollectionHelpers/Collection+Insert.swift
@@ -37,7 +37,7 @@ extension MongoCollection {
                 in: self.transaction,
                 sessionId: self.sessionId ?? connection.implicitSessionId
             )
-        }.decode(InsertReply.self).flatMapThrowing { reply in
+        }.decodeReply(InsertReply.self).flatMapThrowing { reply in
             if reply.ok == 1 {
                 return reply
             }

--- a/Sources/MongoKitten/CollectionHelpers/Collection+Update.swift
+++ b/Sources/MongoKitten/CollectionHelpers/Collection+Update.swift
@@ -16,7 +16,7 @@ extension MongoCollection {
                 in: self.transaction,
                 sessionId: self.sessionId ?? connection.implicitSessionId
             )
-        }.decode(UpdateReply.self)._mongoHop(to: hoppedEventLoop)
+        }.decodeReply(UpdateReply.self)._mongoHop(to: hoppedEventLoop)
     }
     
     public func updateOne<Query: MongoKittenQuery>(
@@ -44,7 +44,7 @@ extension MongoCollection {
                 in: self.transaction,
                 sessionId: self.sessionId ?? connection.implicitSessionId
             )
-        }.decode(UpdateReply.self)._mongoHop(to: hoppedEventLoop)
+        }.decodeReply(UpdateReply.self)._mongoHop(to: hoppedEventLoop)
     }
     
     public func updateMany<Query: MongoKittenQuery>(
@@ -74,7 +74,7 @@ extension MongoCollection {
                 in: self.transaction,
                 sessionId: self.sessionId ?? connection.implicitSessionId
             )
-        }.decode(UpdateReply.self)._mongoHop(to: hoppedEventLoop)
+        }.decodeReply(UpdateReply.self)._mongoHop(to: hoppedEventLoop)
     }
     
     public func upsert(_ document: Document, where query: Document) -> EventLoopFuture<UpdateReply> {
@@ -91,6 +91,6 @@ extension MongoCollection {
                 in: self.transaction,
                 sessionId: self.sessionId ?? connection.implicitSessionId
             )
-        }.decode(UpdateReply.self)._mongoHop(to: hoppedEventLoop)
+        }.decodeReply(UpdateReply.self)._mongoHop(to: hoppedEventLoop)
     }
 }

--- a/Sources/MongoKitten/MongoDatabase.swift
+++ b/Sources/MongoKitten/MongoDatabase.swift
@@ -293,10 +293,23 @@ internal extension Decodable {
 }
 
 extension EventLoopFuture where Value == MongoServerReply {
-    public func decode<D: Decodable>(_ type: D.Type) -> EventLoopFuture<D> {
+    public func decodeReply<D: Decodable>(_ type: D.Type) -> EventLoopFuture<D> {
         return flatMapThrowing(D.init(reply:))
     }
 }
+
+extension EventLoopFuture where Value == Optional<Document> {
+    public func decode<D: Decodable>(_ type: D.Type) -> EventLoopFuture<D?> {
+        return flatMapThrowing { document in
+            if let document = document {
+                return try BSONDecoder().decode(type, from: document)
+            } else {
+                return nil
+            }
+        }
+    }
+}
+
 
 extension MongoConnectionPool {
     public subscript(db: String) -> MongoDatabase {

--- a/Sources/MongoKitten/MongoTransactionDatabase.swift
+++ b/Sources/MongoKitten/MongoTransactionDatabase.swift
@@ -6,7 +6,7 @@ public final class MongoTransactionDatabase: MongoDatabase {
                 namespace: .administrativeCommand,
                 in: self.transaction,
                 sessionId: self.sessionId
-            ).decode(OK.self).map { _ in }
+            ).decodeReply(OK.self).map { _ in }
         }
     }
     
@@ -17,7 +17,7 @@ public final class MongoTransactionDatabase: MongoDatabase {
                 namespace: .administrativeCommand,
                 in: self.transaction,
                 sessionId: self.sessionId
-            ).decode(OK.self).map { _ in }
+            ).decodeReply(OK.self).map { _ in }
         }
     }
 }

--- a/Tests/MongoCoreTests/ProtocolTests.swift
+++ b/Tests/MongoCoreTests/ProtocolTests.swift
@@ -56,7 +56,7 @@ class ProtocolTests: XCTestCase {
             responseTo: 0,
             opCode: .message
         )
-        var document = Document()
+        let document = Document()
         var buffer = allocator.buffer(capacity: 1_024)
         var documentBuffer = document.makeByteBuffer()
         
@@ -64,7 +64,7 @@ class ProtocolTests: XCTestCase {
         buffer.writeInteger(0 as UInt8)
         buffer.writeBuffer(&documentBuffer)
         
-        let message = try OpMessage(reading: &buffer, header: header)
+        _ = try OpMessage(reading: &buffer, header: header)
     }
     
     func testOpMessageDeniesFirstUInt16Flags() throws {


### PR DESCRIPTION
1. Creating a new decode function to be used with findOne() similar to the one already existing and which works with find(). this new decode transforms an EventLoopFuture<Document?> to EventLoopFuture<Codable?> eg:return r.db["CollectionName"].findOne(query).decode(Codable.self).

2. Renaming an existing decode function to "decodeReply" in order to solve naming conflict

3. Address some minor warning