### PR TITLE
Fix two Thread Sanitizer failures

### DIFF
--- a/Sources/MongoClient/Connection.swift
+++ b/Sources/MongoClient/Connection.swift
@@ -2,6 +2,7 @@ import BSON
 import Foundation
 import MongoCore
 import NIO
+import NIOConcurrencyHelpers
 import Logging
 import Metrics
 
@@ -55,7 +56,7 @@ public final class MongoConnection {
     }
 
     /// The current request ID, used to generate unique identifiers for MongoDB commands
-    private var currentRequestId: Int32 = 0
+    private var currentRequestId: NIOAtomic<Int32> = .makeAtomic(value: 0)
     internal let context: MongoClientContext
     public var serverHandshake: ServerHandshake? {
         return context.serverHandshake
@@ -71,9 +72,7 @@ public final class MongoConnection {
     public var slaveOk = false
 
     internal func nextRequestId() -> Int32 {
-        defer { currentRequestId = currentRequestId &+ 1 }
-
-        return currentRequestId
+        return currentRequestId.add(1)
     }
 
     /// Creates a connection that can communicate with MongoDB over a channel

--- a/Tests/MongoCoreTests/ProtocolTests.swift
+++ b/Tests/MongoCoreTests/ProtocolTests.swift
@@ -64,10 +64,6 @@ class ProtocolTests: XCTestCase {
         buffer.writeInteger(0 as UInt8)
         buffer.writeBuffer(&documentBuffer)
         
-        _ = try OpMessage(reading: &buffer, header: header)
-    }
-    
-    func testOpMessageDeniesFirstUInt16Flags() throws {
         XCTAssertNoThrow(try OpMessage(reading: &buffer, header: header))
     }
 }


### PR DESCRIPTION
## Description

Two Thread Sanitizer failures were encountered while running the full test suite of Fluent's (https://github.com/vapor/fluent) MongoDB driver (https://github.com/vapor/fluent-mongo-driver). The test suite was running in modified form when the failures appeared, specifically:

1. Use a `MultiThreadedEventLoopGroup` configured with `System.coreCount` threads instead of `1`.
1. Use an `NIOThreadPool` configured the same way (again, instead of the usual one).

### Failure 1

The first failure is a race condition caused by multiple threads attempting to access the `currentRequestId` of the same `MongoConnection` with no synchronization. An occurrence of this race condition in production might manifest as multiple reuses of the same request ID, or as one or more IDs being skipped. My chosen fix was to wrap the `currentRequestId` property with NIO's `NIOAtomic` helper. (It is not clear that this is a complete fix, however. A rule of thumb when considering the use of atomic variables is to assume you're wrong to believe that the use is correct. A lock would be a safer, if much blunter, instrument. For the moment I've left this as-is in favor of inviting further discussion on the subject.)

Full Thread Sanitizer backtrace: https://gist.github.com/gwynne/f95f6eb279f445c844b18f654c073f15

### Failure 2

The second failure is also a race condition, this time caused by multiple threads invoking methods on the same `MongoClientContext` which access the `queries` property. An occurrence of this race condition in production would most likely manifest as a crash secondary to corruption of the `Array`'s internal structures. My chosen fix was to apply NIO's `Lock` helper to all observations and mutations of the property. It was critical to make any `query.result.succeed()` and `query.result.fail()` calls _after_ releasing the lock; otherwise the effects of those calls could result in deadlock by attempting to access the array again on the same thread before returning from the method.

_Note: My use of the term `stolenQueries` in the `cancelQueries(_:)` method is a reference to traditional usage working with linked list structures in C and other lower-level languages, where to "steal" a list is to atomically swap the list head pointer with an entirely different (or empty) list - a very fast way to safely remove all items so they can be operated on without additional locking. My implementation is not as efficient as that, but has the same result._

Full Thread Sanitizer backtrace: https://gist.github.com/gwynne/ac4071590dae0c9200b8e7de77c6ac32

## How Has This Been Tested?

Having implemented both fixes, I re-ran both MongoKitten's own units tests and the Fluent test suite again multiple times, both with and without Thread Sanitizer active. No further failures appeared.

MongoKitten's tests failed to compile at first; based on the previous commit history of the failing line and its containing file, I effected a revert of this change: https://github.com/OpenKitten/MongoKitten/commit/bfd3cef57de7cda70ba624243834c93813cf69fd#diff-31aa460cf7fcf07056125529125cd029R67-R70

This was sufficient to restore the tests to a building state.