### PR TITLE
Update AggregateBuilderStage

### DIFF
--- a/Sources/MongoKitten/AggregateStage.swift
+++ b/Sources/MongoKitten/AggregateStage.swift
@@ -1,13 +1,13 @@
 import MongoClient
 
 public struct AggregateBuilderStage {
-    internal var stages: [Document]
+    public internal(set) var stages: [Document]
     
     public init(document: Document) {
         self.stages = [document]
     }
     
-    internal init(documents: [Document]) {
+    public init(documents: [Document]) {
         self.stages = documents
     }
     

--- a/Sources/MongoKitten/AggregateStage.swift
+++ b/Sources/MongoKitten/AggregateStage.swift
@@ -59,8 +59,6 @@ public struct AggregateBuilderStage {
     }
     
     public static func skip(_ n: Int) -> AggregateBuilderStage {
-        assert(n > 0)
-        
         return AggregateBuilderStage(document: [
             "$skip": n
         ])

--- a/Sources/MongoKitten/AggregateStage.swift
+++ b/Sources/MongoKitten/AggregateStage.swift
@@ -59,6 +59,8 @@ public struct AggregateBuilderStage {
     }
     
     public static func skip(_ n: Int) -> AggregateBuilderStage {
+        assert(n > -1)
+        
         return AggregateBuilderStage(document: [
             "$skip": n
         ])


### PR DESCRIPTION
## Description
I updated AggregateBuilderStage with 2 tiny updates :
- Modified *assert* condition in **skip**, to work with `0` as value
- Modified access-controles for **AggregateBuilderStage** Struct to create custom object with many documents

## Motivation
The modification on access-controles for **AggregateBuilderStage**, allow to create custom a new AggregateBuilderStage with many document outside the MongoKitten package.

## How Has This Been Tested?
- Skip: no unit test 😬  but tested in Mongo Shell
- New access-controles: a new unit test 😎 

## Checklist:
- [ ] If applicable, I have updated the documentation accordingly.
- [x] If applicable, I have added tests to cover my changes.