### PR TITLE
Added decoder helper.

### DIFF
--- a/Sources/MongoKitten/CollectionHelpers/Collection+FindAndModify.swift
+++ b/Sources/MongoKitten/CollectionHelpers/Collection+FindAndModify.swift
@@ -136,6 +136,10 @@ public final class FindAndModifyBuilder {
         .decodeReply(FindAndModifyReply.self)
         ._mongoHop(to: self.collection.hoppedEventLoop)
     }
+
+    public func decode<D: Decodable>(_ type: D.Type) -> EventLoopFuture<D?> {
+        self.execute().map(\.value).decode(type)
+    }
     
     public func sort(_ sort: Sort) -> FindAndModifyBuilder {
         self.command.sort = sort.document


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Adds a helpful `decode()` function the the `FindAndModifyQueryBuilder`

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This helps making these commands cleaner and more in line with the cursor based API.
So we can go from this :
```swift
findOneAndUpdate(where: "_id" == ObjectId(),
                 to: ["$set": ["field": "value"]],
                 returnValue: .modified)
        .execute()
        .map(\.value)
        .decode(PayoutDetailsResponse.self)
```

To this:
```swift
findOneAndUpdate(where: "_id" == ObjectId(),
                 to: ["$set": ["field": "value"]],
                 returnValue: .modified)
.decode(PayoutDetailsResponse.self)
```