### PR TITLE
Update AggregateBuilder.swift

### DIFF
--- a/Sources/MongoKitten/AggregateBuilder.swift
+++ b/Sources/MongoKitten/AggregateBuilder.swift
@@ -1,7 +1,7 @@
 import MongoClient
 import NIO
 
-#if swift(>=5.3)
+#if swift(>=5.4)
 @resultBuilder
 public struct AggregateBuilder {
     public static func buildBlock() -> AggregateBuilderPipeline {


### PR DESCRIPTION
Bumped guard to 5.4 as `resultBuilder` was introduced in Swift 5.4